### PR TITLE
Keep grid indices within boundaries of CHM

### DIFF
--- a/docs/_build/html/_modules/pointtree/instance_segmentation/_multi_stage_algorithm.html
+++ b/docs/_build/html/_modules/pointtree/instance_segmentation/_multi_stage_algorithm.html
@@ -869,492 +869,495 @@
 </span><span id="line-680">                        <span class="n">tree_positions</span><span class="o">=</span><span class="n">tree_positions_grid</span><span class="p">,</span>
 </span><span id="line-681">                    <span class="p">)</span>
 </span><span id="line-682">
-</span><span id="line-683">            <span class="n">mask</span> <span class="o">=</span> <span class="n">instance_ids</span> <span class="o">==</span> <span class="o">-</span><span class="mi">1</span>
-</span><span id="line-684">            <span class="n">grid_indices</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">floor</span><span class="p">(</span>
-</span><span id="line-685">                <span class="p">(</span><span class="n">tree_coords</span><span class="p">[</span><span class="n">mask</span><span class="p">][:,</span> <span class="p">:</span><span class="mi">2</span><span class="p">]</span> <span class="o">-</span> <span class="n">grid_origin</span><span class="p">)</span> <span class="o">/</span> <span class="bp">self</span><span class="o">.</span><span class="n">_grid_size_canopy_height_model</span>
-</span><span id="line-686">            <span class="p">)</span><span class="o">.</span><span class="n">astype</span><span class="p">(</span><span class="nb">int</span><span class="p">)</span>
-</span><span id="line-687">            <span class="n">instance_ids</span><span class="p">[</span><span class="n">mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">grid_indices</span><span class="p">[:,</span> <span class="mi">0</span><span class="p">],</span> <span class="n">grid_indices</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]]</span> <span class="o">-</span> <span class="mi">1</span>
-</span><span id="line-688">            <span class="n">instance_ids</span><span class="p">,</span> <span class="n">unique_instance_ids</span> <span class="o">=</span> <span class="n">remap_instance_ids</span><span class="p">(</span><span class="n">instance_ids</span><span class="p">)</span>
-</span><span id="line-689">
-</span><span id="line-690">        <span class="k">return</span> <span class="p">(</span>
-</span><span id="line-691">            <span class="n">instance_ids</span><span class="p">,</span>
-</span><span id="line-692">            <span class="n">unique_instance_ids</span><span class="p">,</span>
-</span><span id="line-693">            <span class="n">watershed_labels_with_border</span><span class="p">,</span>
-</span><span id="line-694">            <span class="n">watershed_labels_without_border</span><span class="p">,</span>
-</span><span id="line-695">        <span class="p">)</span></div>
+</span><span id="line-683">            <span class="n">grid_indices</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">floor</span><span class="p">((</span><span class="n">tree_coords</span><span class="p">[:,</span> <span class="p">:</span><span class="mi">2</span><span class="p">]</span> <span class="o">-</span> <span class="n">grid_origin</span><span class="p">)</span> <span class="o">/</span> <span class="bp">self</span><span class="o">.</span><span class="n">_grid_size_canopy_height_model</span><span class="p">)</span><span class="o">.</span><span class="n">astype</span><span class="p">(</span>
+</span><span id="line-684">                <span class="nb">int</span>
+</span><span id="line-685">            <span class="p">)</span>
+</span><span id="line-686">            <span class="n">mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
+</span><span id="line-687">                <span class="n">instance_ids</span> <span class="o">==</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="p">(</span><span class="n">grid_indices</span> <span class="o">&lt;</span> <span class="n">watershed_labels_without_border</span><span class="o">.</span><span class="n">shape</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">(</span><span class="n">axis</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
+</span><span id="line-688">            <span class="p">)</span>
+</span><span id="line-689">            <span class="n">grid_indices</span> <span class="o">=</span> <span class="n">grid_indices</span><span class="p">[</span><span class="n">mask</span><span class="p">]</span>
+</span><span id="line-690">            <span class="n">instance_ids</span><span class="p">[</span><span class="n">mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">grid_indices</span><span class="p">[:,</span> <span class="mi">0</span><span class="p">],</span> <span class="n">grid_indices</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]]</span> <span class="o">-</span> <span class="mi">1</span>
+</span><span id="line-691">            <span class="n">instance_ids</span><span class="p">,</span> <span class="n">unique_instance_ids</span> <span class="o">=</span> <span class="n">remap_instance_ids</span><span class="p">(</span><span class="n">instance_ids</span><span class="p">)</span>
+</span><span id="line-692">
+</span><span id="line-693">        <span class="k">return</span> <span class="p">(</span>
+</span><span id="line-694">            <span class="n">instance_ids</span><span class="p">,</span>
+</span><span id="line-695">            <span class="n">unique_instance_ids</span><span class="p">,</span>
+</span><span id="line-696">            <span class="n">watershed_labels_with_border</span><span class="p">,</span>
+</span><span id="line-697">            <span class="n">watershed_labels_without_border</span><span class="p">,</span>
+</span><span id="line-698">        <span class="p">)</span></div>
 
-</span><span id="line-696">
+</span><span id="line-699">
 <div class="viewcode-block" id="MultiStageAlgorithm.watershed_segmentation">
 <a class="viewcode-back" href="../../../pointtree.instance_segmentation.html#pointtree.instance_segmentation.MultiStageAlgorithm.watershed_segmentation">[docs]</a>
-</span><span id="line-697">    <span class="k">def</span> <span class="nf">watershed_segmentation</span><span class="p">(</span>
-</span><span id="line-698">        <span class="bp">self</span><span class="p">,</span> <span class="n">canopy_height_model</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">tree_positions_grid</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span>
-</span><span id="line-699">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">]:</span>
-</span><span id="line-700"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
-</span><span id="line-701"><span class="sd">        Marker-controlled Watershed segmentation of the canopy height model.</span>
-</span><span id="line-702">
-</span><span id="line-703"><span class="sd">        Args:</span>
-</span><span id="line-704"><span class="sd">            canopy_height_model: The canopy height model to segment.</span>
-</span><span id="line-705"><span class="sd">            tree_positions_grid: Indices of the grid cells of the canopy height model in which the tree positions are</span>
-</span><span id="line-706"><span class="sd">                located.</span>
-</span><span id="line-707">
-</span><span id="line-708"><span class="sd">        Returns:</span>
-</span><span id="line-709"><span class="sd">            Tuple of two arrays. The first contains the Watershed segmentation mask with the pixels at the boundary</span>
-</span><span id="line-710"><span class="sd">            lines between neighboring trees are assigned the background value of 0. The second contains the same</span>
-</span><span id="line-711"><span class="sd">            Watershed segmentation mask without boundary lines.</span>
-</span><span id="line-712">
-</span><span id="line-713"><span class="sd">        Shape:</span>
-</span><span id="line-714"><span class="sd">            - :code:`canopy_height_model`: :math:`(W, H)`</span>
-</span><span id="line-715"><span class="sd">            - :code:`tree_positions_grid`: :math:`(I, 2)`</span>
-</span><span id="line-716"><span class="sd">            - Output: Tuple of two arrays. Both have shape :math:`(W, H)`.</span>
-</span><span id="line-717">
-</span><span id="line-718"><span class="sd">            | where</span>
-</span><span id="line-719"><span class="sd">            |</span>
-</span><span id="line-720"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
-</span><span id="line-721"><span class="sd">            | :math:`W = \text{ extent of the canopy height model in x-direction}`</span>
-</span><span id="line-722"><span class="sd">            | :math:`H = \text{ extent of the canopy height model in y-direction}`</span>
-</span><span id="line-723"><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="line-724">
-</span><span id="line-725">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Watershed segmentation&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
-</span><span id="line-726">            <span class="n">watershed_markers</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">canopy_height_model</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
-</span><span id="line-727">            <span class="n">watershed_markers</span><span class="p">[</span><span class="n">tree_positions_grid</span><span class="p">[:,</span> <span class="mi">0</span><span class="p">],</span> <span class="n">tree_positions_grid</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span>
-</span><span id="line-728">                <span class="mi">1</span><span class="p">,</span> <span class="nb">len</span><span class="p">(</span><span class="n">tree_positions_grid</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span>
-</span><span id="line-729">            <span class="p">)</span>
-</span><span id="line-730">
-</span><span id="line-731">            <span class="n">foreground_mask</span> <span class="o">=</span> <span class="n">canopy_height_model</span> <span class="o">&gt;</span> <span class="mi">0</span>
-</span><span id="line-732">
-</span><span id="line-733">            <span class="c1"># retrieve crown border and seed areas</span>
-</span><span id="line-734">            <span class="n">watershed_labels_with_border</span> <span class="o">=</span> <span class="n">watershed</span><span class="p">(</span>
-</span><span id="line-735">                <span class="o">-</span><span class="n">canopy_height_model</span><span class="p">,</span> <span class="n">watershed_markers</span><span class="p">,</span> <span class="n">mask</span><span class="o">=</span><span class="n">foreground_mask</span><span class="p">,</span> <span class="n">watershed_line</span><span class="o">=</span><span class="kc">True</span>
-</span><span id="line-736">            <span class="p">)</span>
-</span><span id="line-737">            <span class="n">border_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">watershed_labels_with_border</span> <span class="o">==</span> <span class="mi">0</span><span class="p">,</span> <span class="n">foreground_mask</span><span class="p">)</span>
-</span><span id="line-738">            <span class="n">watershed_labels_without_border</span> <span class="o">=</span> <span class="n">watershed_labels_with_border</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
-</span><span id="line-739">            <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">border_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">watershed_labels_with_border</span><span class="p">,</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">))[</span>
-</span><span id="line-740">                <span class="n">border_mask</span>
-</span><span id="line-741">            <span class="p">]</span>
-</span><span id="line-742">
-</span><span id="line-743">        <span class="k">return</span> <span class="n">watershed_labels_with_border</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span></div>
+</span><span id="line-700">    <span class="k">def</span> <span class="nf">watershed_segmentation</span><span class="p">(</span>
+</span><span id="line-701">        <span class="bp">self</span><span class="p">,</span> <span class="n">canopy_height_model</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">tree_positions_grid</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span>
+</span><span id="line-702">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">]:</span>
+</span><span id="line-703"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="line-704"><span class="sd">        Marker-controlled Watershed segmentation of the canopy height model.</span>
+</span><span id="line-705">
+</span><span id="line-706"><span class="sd">        Args:</span>
+</span><span id="line-707"><span class="sd">            canopy_height_model: The canopy height model to segment.</span>
+</span><span id="line-708"><span class="sd">            tree_positions_grid: Indices of the grid cells of the canopy height model in which the tree positions are</span>
+</span><span id="line-709"><span class="sd">                located.</span>
+</span><span id="line-710">
+</span><span id="line-711"><span class="sd">        Returns:</span>
+</span><span id="line-712"><span class="sd">            Tuple of two arrays. The first contains the Watershed segmentation mask with the pixels at the boundary</span>
+</span><span id="line-713"><span class="sd">            lines between neighboring trees are assigned the background value of 0. The second contains the same</span>
+</span><span id="line-714"><span class="sd">            Watershed segmentation mask without boundary lines.</span>
+</span><span id="line-715">
+</span><span id="line-716"><span class="sd">        Shape:</span>
+</span><span id="line-717"><span class="sd">            - :code:`canopy_height_model`: :math:`(W, H)`</span>
+</span><span id="line-718"><span class="sd">            - :code:`tree_positions_grid`: :math:`(I, 2)`</span>
+</span><span id="line-719"><span class="sd">            - Output: Tuple of two arrays. Both have shape :math:`(W, H)`.</span>
+</span><span id="line-720">
+</span><span id="line-721"><span class="sd">            | where</span>
+</span><span id="line-722"><span class="sd">            |</span>
+</span><span id="line-723"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
+</span><span id="line-724"><span class="sd">            | :math:`W = \text{ extent of the canopy height model in x-direction}`</span>
+</span><span id="line-725"><span class="sd">            | :math:`H = \text{ extent of the canopy height model in y-direction}`</span>
+</span><span id="line-726"><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="line-727">
+</span><span id="line-728">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Watershed segmentation&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
+</span><span id="line-729">            <span class="n">watershed_markers</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">canopy_height_model</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
+</span><span id="line-730">            <span class="n">watershed_markers</span><span class="p">[</span><span class="n">tree_positions_grid</span><span class="p">[:,</span> <span class="mi">0</span><span class="p">],</span> <span class="n">tree_positions_grid</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]]</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span>
+</span><span id="line-731">                <span class="mi">1</span><span class="p">,</span> <span class="nb">len</span><span class="p">(</span><span class="n">tree_positions_grid</span><span class="p">)</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span>
+</span><span id="line-732">            <span class="p">)</span>
+</span><span id="line-733">
+</span><span id="line-734">            <span class="n">foreground_mask</span> <span class="o">=</span> <span class="n">canopy_height_model</span> <span class="o">&gt;</span> <span class="mi">0</span>
+</span><span id="line-735">
+</span><span id="line-736">            <span class="c1"># retrieve crown border and seed areas</span>
+</span><span id="line-737">            <span class="n">watershed_labels_with_border</span> <span class="o">=</span> <span class="n">watershed</span><span class="p">(</span>
+</span><span id="line-738">                <span class="o">-</span><span class="n">canopy_height_model</span><span class="p">,</span> <span class="n">watershed_markers</span><span class="p">,</span> <span class="n">mask</span><span class="o">=</span><span class="n">foreground_mask</span><span class="p">,</span> <span class="n">watershed_line</span><span class="o">=</span><span class="kc">True</span>
+</span><span id="line-739">            <span class="p">)</span>
+</span><span id="line-740">            <span class="n">border_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">watershed_labels_with_border</span> <span class="o">==</span> <span class="mi">0</span><span class="p">,</span> <span class="n">foreground_mask</span><span class="p">)</span>
+</span><span id="line-741">            <span class="n">watershed_labels_without_border</span> <span class="o">=</span> <span class="n">watershed_labels_with_border</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
+</span><span id="line-742">            <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">border_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">watershed_labels_with_border</span><span class="p">,</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">))[</span>
+</span><span id="line-743">                <span class="n">border_mask</span>
+</span><span id="line-744">            <span class="p">]</span>
+</span><span id="line-745">
+</span><span id="line-746">        <span class="k">return</span> <span class="n">watershed_labels_with_border</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span></div>
 
-</span><span id="line-744">
+</span><span id="line-747">
 <div class="viewcode-block" id="MultiStageAlgorithm.watershed_correction">
 <a class="viewcode-back" href="../../../pointtree.instance_segmentation.html#pointtree.instance_segmentation.MultiStageAlgorithm.watershed_correction">[docs]</a>
-</span><span id="line-745">    <span class="k">def</span> <span class="nf">watershed_correction</span><span class="p">(</span>  <span class="c1"># pylint: disable=too-many-locals</span>
-</span><span id="line-746">        <span class="bp">self</span><span class="p">,</span>
-</span><span id="line-747">        <span class="n">watershed_labels_with_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-748">        <span class="n">watershed_labels_without_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-749">        <span class="n">tree_positions_grid</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-750">        <span class="n">point_cloud_id</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="line-751">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">]:</span>
-</span><span id="line-752"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
-</span><span id="line-753"><span class="sd">        Detects erroneous parts within a Watershed segmentation mask and replaces them by a Voronoi segmentation.</span>
-</span><span id="line-754">
-</span><span id="line-755"><span class="sd">        Args:</span>
-</span><span id="line-756"><span class="sd">            watershed_labels_with_border: Uncorrected Watershed labels with boundary lines between neighboring</span>
-</span><span id="line-757"><span class="sd">                trees are assigned the background value of 0.</span>
-</span><span id="line-758"><span class="sd">            watershed_labels_without_border: Uncorrected Watershed labels without boundary lines.</span>
-</span><span id="line-759"><span class="sd">            tree_positions_grid: Indices of the grid cells of the canopy height model in which the tree positions are</span>
-</span><span id="line-760"><span class="sd">                located.</span>
-</span><span id="line-761"><span class="sd">            point_cloud_id: ID of the point cloud to be used in the file names of the visualization results. Defaults to</span>
-</span><span id="line-762"><span class="sd">                `None`, which means that no visualizations are created.</span>
-</span><span id="line-763">
-</span><span id="line-764"><span class="sd">        Returns:</span>
-</span><span id="line-765"><span class="sd">            Tuple of two arrays. The first contains the corrected Watershed segmentation mask with the pixels at the</span>
-</span><span id="line-766"><span class="sd">            boundary lines between neighboring trees are assigned the background value of 0. The second contains the</span>
-</span><span id="line-767"><span class="sd">            same Watershed segmentation mask without boundary lines.</span>
-</span><span id="line-768">
-</span><span id="line-769"><span class="sd">        Shape:</span>
-</span><span id="line-770"><span class="sd">            - :code:`watershed_labels_with_border`: :math:`(W, H)`</span>
-</span><span id="line-771"><span class="sd">            - :code:`watershed_labels_without_border`: :math:`(W, H)`</span>
-</span><span id="line-772"><span class="sd">            - :code:`tree_positions_grid`: :math:`(I, 2)`</span>
-</span><span id="line-773"><span class="sd">            - Output: Tuple of two arrays. Both have shape :math:`(W, H)`.</span>
-</span><span id="line-774">
-</span><span id="line-775"><span class="sd">            | where</span>
-</span><span id="line-776"><span class="sd">            |</span>
-</span><span id="line-777"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
-</span><span id="line-778"><span class="sd">            | :math:`W = \text{ extent of the canopy height model in x-direction}`</span>
-</span><span id="line-779"><span class="sd">            | :math:`H = \text{ extent of the canopy height model in y-direction}`</span>
-</span><span id="line-780"><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="line-781">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s1">&#39;&quot;Watershed correction&#39;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
-</span><span id="line-782">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Correct Watershed segmentation...&quot;</span><span class="p">)</span>
-</span><span id="line-783">            <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">):</span>
-</span><span id="line-784">                <span class="k">if</span> <span class="n">instance_id</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>  <span class="c1"># background</span>
-</span><span id="line-785">                    <span class="k">continue</span>
-</span><span id="line-786">
-</span><span id="line-787">                <span class="n">instance_mask</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">instance_id</span>
-</span><span id="line-788">
-</span><span id="line-789">                <span class="n">footprint</span> <span class="o">=</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
-</span><span id="line-790">                <span class="n">dilated_instance_mask</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">instance_mask</span><span class="p">,</span> <span class="n">footprint</span><span class="p">)</span>
-</span><span id="line-791">                <span class="n">neighbor_instance_ids</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">dilated_instance_mask</span><span class="p">])</span>
-</span><span id="line-792">
-</span><span id="line-793">                <span class="k">if</span> <span class="n">instance_mask</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">==</span> <span class="mi">1</span> <span class="ow">or</span> <span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">neighbor_instance_ids</span><span class="p">)</span> <span class="o">==</span> <span class="mi">2</span><span class="p">)</span> <span class="ow">and</span> <span class="p">(</span><span class="mi">0</span> <span class="ow">not</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">):</span>
-</span><span id="line-794">                    <span class="n">neighbor_instance_ids</span> <span class="o">=</span> <span class="n">neighbor_instance_ids</span><span class="p">[</span><span class="n">neighbor_instance_ids</span> <span class="o">!=</span> <span class="mi">0</span><span class="p">]</span>
+</span><span id="line-748">    <span class="k">def</span> <span class="nf">watershed_correction</span><span class="p">(</span>  <span class="c1"># pylint: disable=too-many-locals</span>
+</span><span id="line-749">        <span class="bp">self</span><span class="p">,</span>
+</span><span id="line-750">        <span class="n">watershed_labels_with_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-751">        <span class="n">watershed_labels_without_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-752">        <span class="n">tree_positions_grid</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-753">        <span class="n">point_cloud_id</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="line-754">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">]:</span>
+</span><span id="line-755"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="line-756"><span class="sd">        Detects erroneous parts within a Watershed segmentation mask and replaces them by a Voronoi segmentation.</span>
+</span><span id="line-757">
+</span><span id="line-758"><span class="sd">        Args:</span>
+</span><span id="line-759"><span class="sd">            watershed_labels_with_border: Uncorrected Watershed labels with boundary lines between neighboring</span>
+</span><span id="line-760"><span class="sd">                trees are assigned the background value of 0.</span>
+</span><span id="line-761"><span class="sd">            watershed_labels_without_border: Uncorrected Watershed labels without boundary lines.</span>
+</span><span id="line-762"><span class="sd">            tree_positions_grid: Indices of the grid cells of the canopy height model in which the tree positions are</span>
+</span><span id="line-763"><span class="sd">                located.</span>
+</span><span id="line-764"><span class="sd">            point_cloud_id: ID of the point cloud to be used in the file names of the visualization results. Defaults to</span>
+</span><span id="line-765"><span class="sd">                `None`, which means that no visualizations are created.</span>
+</span><span id="line-766">
+</span><span id="line-767"><span class="sd">        Returns:</span>
+</span><span id="line-768"><span class="sd">            Tuple of two arrays. The first contains the corrected Watershed segmentation mask with the pixels at the</span>
+</span><span id="line-769"><span class="sd">            boundary lines between neighboring trees are assigned the background value of 0. The second contains the</span>
+</span><span id="line-770"><span class="sd">            same Watershed segmentation mask without boundary lines.</span>
+</span><span id="line-771">
+</span><span id="line-772"><span class="sd">        Shape:</span>
+</span><span id="line-773"><span class="sd">            - :code:`watershed_labels_with_border`: :math:`(W, H)`</span>
+</span><span id="line-774"><span class="sd">            - :code:`watershed_labels_without_border`: :math:`(W, H)`</span>
+</span><span id="line-775"><span class="sd">            - :code:`tree_positions_grid`: :math:`(I, 2)`</span>
+</span><span id="line-776"><span class="sd">            - Output: Tuple of two arrays. Both have shape :math:`(W, H)`.</span>
+</span><span id="line-777">
+</span><span id="line-778"><span class="sd">            | where</span>
+</span><span id="line-779"><span class="sd">            |</span>
+</span><span id="line-780"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
+</span><span id="line-781"><span class="sd">            | :math:`W = \text{ extent of the canopy height model in x-direction}`</span>
+</span><span id="line-782"><span class="sd">            | :math:`H = \text{ extent of the canopy height model in y-direction}`</span>
+</span><span id="line-783"><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="line-784">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s1">&#39;&quot;Watershed correction&#39;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
+</span><span id="line-785">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Correct Watershed segmentation...&quot;</span><span class="p">)</span>
+</span><span id="line-786">            <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">):</span>
+</span><span id="line-787">                <span class="k">if</span> <span class="n">instance_id</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>  <span class="c1"># background</span>
+</span><span id="line-788">                    <span class="k">continue</span>
+</span><span id="line-789">
+</span><span id="line-790">                <span class="n">instance_mask</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">instance_id</span>
+</span><span id="line-791">
+</span><span id="line-792">                <span class="n">footprint</span> <span class="o">=</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
+</span><span id="line-793">                <span class="n">dilated_instance_mask</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">instance_mask</span><span class="p">,</span> <span class="n">footprint</span><span class="p">)</span>
+</span><span id="line-794">                <span class="n">neighbor_instance_ids</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">dilated_instance_mask</span><span class="p">])</span>
 </span><span id="line-795">
-</span><span id="line-796">                    <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
-</span><span id="line-797">                        <span class="s2">&quot;Detected inaccurate watershed segmentation for tree </span><span class="si">%d</span><span class="s2">. Falling back to Voronoi&quot;</span>
-</span><span id="line-798">                        <span class="o">+</span> <span class="s2">&quot; segmentation.&quot;</span><span class="p">,</span>
-</span><span id="line-799">                        <span class="n">instance_id</span><span class="p">,</span>
-</span><span id="line-800">                    <span class="p">)</span>
-</span><span id="line-801">
-</span><span id="line-802">                    <span class="n">neighborhood_mask_without_border</span> <span class="o">=</span> <span class="n">instance_mask</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
-</span><span id="line-803">                    <span class="n">neighborhood_mask_with_border</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
-</span><span id="line-804">                        <span class="n">dilated_instance_mask</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span> <span class="o">!=</span> <span class="mi">0</span>
-</span><span id="line-805">                    <span class="p">)</span>
-</span><span id="line-806">                    <span class="k">for</span> <span class="n">neighbor_id</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">:</span>
-</span><span id="line-807">                        <span class="n">neighborhood_mask_without_border</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span>
-</span><span id="line-808">                            <span class="n">neighborhood_mask_without_border</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">neighbor_id</span>
-</span><span id="line-809">                        <span class="p">)</span>
-</span><span id="line-810">                        <span class="n">neighborhood_mask_with_border</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span>
-</span><span id="line-811">                            <span class="n">neighborhood_mask_with_border</span><span class="p">,</span> <span class="n">watershed_labels_with_border</span> <span class="o">==</span> <span class="n">neighbor_id</span>
+</span><span id="line-796">                <span class="k">if</span> <span class="n">instance_mask</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">==</span> <span class="mi">1</span> <span class="ow">or</span> <span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">neighbor_instance_ids</span><span class="p">)</span> <span class="o">==</span> <span class="mi">2</span><span class="p">)</span> <span class="ow">and</span> <span class="p">(</span><span class="mi">0</span> <span class="ow">not</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">):</span>
+</span><span id="line-797">                    <span class="n">neighbor_instance_ids</span> <span class="o">=</span> <span class="n">neighbor_instance_ids</span><span class="p">[</span><span class="n">neighbor_instance_ids</span> <span class="o">!=</span> <span class="mi">0</span><span class="p">]</span>
+</span><span id="line-798">
+</span><span id="line-799">                    <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
+</span><span id="line-800">                        <span class="s2">&quot;Detected inaccurate watershed segmentation for tree </span><span class="si">%d</span><span class="s2">. Falling back to Voronoi&quot;</span>
+</span><span id="line-801">                        <span class="o">+</span> <span class="s2">&quot; segmentation.&quot;</span><span class="p">,</span>
+</span><span id="line-802">                        <span class="n">instance_id</span><span class="p">,</span>
+</span><span id="line-803">                    <span class="p">)</span>
+</span><span id="line-804">
+</span><span id="line-805">                    <span class="n">neighborhood_mask_without_border</span> <span class="o">=</span> <span class="n">instance_mask</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
+</span><span id="line-806">                    <span class="n">neighborhood_mask_with_border</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
+</span><span id="line-807">                        <span class="n">dilated_instance_mask</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span> <span class="o">!=</span> <span class="mi">0</span>
+</span><span id="line-808">                    <span class="p">)</span>
+</span><span id="line-809">                    <span class="k">for</span> <span class="n">neighbor_id</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">:</span>
+</span><span id="line-810">                        <span class="n">neighborhood_mask_without_border</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span>
+</span><span id="line-811">                            <span class="n">neighborhood_mask_without_border</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">neighbor_id</span>
 </span><span id="line-812">                        <span class="p">)</span>
-</span><span id="line-813">
-</span><span id="line-814">                    <span class="n">current_tree_positions</span> <span class="o">=</span> <span class="n">tree_positions_grid</span><span class="p">[</span><span class="n">neighbor_instance_ids</span> <span class="o">-</span> <span class="mi">1</span><span class="p">]</span>
-</span><span id="line-815">                    <span class="n">voronoi_input</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">uint32</span><span class="p">)</span>
+</span><span id="line-813">                        <span class="n">neighborhood_mask_with_border</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span>
+</span><span id="line-814">                            <span class="n">neighborhood_mask_with_border</span><span class="p">,</span> <span class="n">watershed_labels_with_border</span> <span class="o">==</span> <span class="n">neighbor_id</span>
+</span><span id="line-815">                        <span class="p">)</span>
 </span><span id="line-816">
-</span><span id="line-817">                    <span class="n">voronoi_input</span><span class="p">[</span><span class="n">current_tree_positions</span><span class="p">[:,</span> <span class="mi">0</span><span class="p">],</span> <span class="n">current_tree_positions</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]]</span> <span class="o">=</span> <span class="n">neighbor_instance_ids</span>
-</span><span id="line-818">
-</span><span id="line-819">                    <span class="c1"># when all pixels are assigned the same height value, the Watershed algorithm approximates a Voronoi</span>
-</span><span id="line-820">                    <span class="c1"># segmentation</span>
-</span><span id="line-821">                    <span class="n">voronoi_labels_with_border</span> <span class="o">=</span> <span class="n">watershed</span><span class="p">(</span>
-</span><span id="line-822">                        <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">voronoi_input</span><span class="p">),</span>
-</span><span id="line-823">                        <span class="n">voronoi_input</span><span class="p">,</span>
-</span><span id="line-824">                        <span class="n">mask</span><span class="o">=</span><span class="n">neighborhood_mask_with_border</span><span class="p">,</span>
-</span><span id="line-825">                        <span class="n">watershed_line</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
-</span><span id="line-826">                    <span class="p">)</span>
-</span><span id="line-827">                    <span class="n">border_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">voronoi_labels_with_border</span> <span class="o">==</span> <span class="mi">0</span><span class="p">,</span> <span class="n">neighborhood_mask_with_border</span><span class="p">)</span>
-</span><span id="line-828">                    <span class="n">voronoi_labels_without_border</span> <span class="o">=</span> <span class="n">voronoi_labels_with_border</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
-</span><span id="line-829">                    <span class="n">voronoi_labels_without_border</span><span class="p">[</span><span class="n">border_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">voronoi_labels_with_border</span><span class="p">,</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">))[</span>
-</span><span id="line-830">                        <span class="n">border_mask</span>
-</span><span id="line-831">                    <span class="p">]</span>
-</span><span id="line-832">
-</span><span id="line-833">                    <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="ow">and</span> <span class="n">point_cloud_id</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="line-834">                        <span class="n">img_path</span> <span class="o">=</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span><span class="si">}</span><span class="s2">/voronoi_input_</span><span class="si">{</span><span class="n">point_cloud_id</span><span class="si">}</span><span class="s2">_</span><span class="si">{</span><span class="n">instance_id</span><span class="si">}</span><span class="s2">.png&quot;</span>
-</span><span id="line-835">                        <span class="n">save_tree_map</span><span class="p">(</span>
-</span><span id="line-836">                            <span class="n">voronoi_input</span><span class="p">,</span>
-</span><span id="line-837">                            <span class="n">output_path</span><span class="o">=</span><span class="n">img_path</span><span class="p">,</span>
-</span><span id="line-838">                            <span class="n">is_label_image</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
-</span><span id="line-839">                        <span class="p">)</span>
-</span><span id="line-840">
-</span><span id="line-841">                        <span class="n">img_path</span> <span class="o">=</span> <span class="p">(</span>
-</span><span id="line-842">                            <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span><span class="si">}</span><span class="s2">/voronoi_labels_without_border_</span><span class="si">{</span><span class="n">point_cloud_id</span><span class="si">}</span><span class="s2">_&quot;</span>
-</span><span id="line-843">                            <span class="o">+</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">instance_id</span><span class="si">}</span><span class="s2">.png&quot;</span>
-</span><span id="line-844">                        <span class="p">)</span>
-</span><span id="line-845">                        <span class="n">save_tree_map</span><span class="p">(</span>
-</span><span id="line-846">                            <span class="n">voronoi_labels_without_border</span><span class="p">,</span>
-</span><span id="line-847">                            <span class="n">output_path</span><span class="o">=</span><span class="n">img_path</span><span class="p">,</span>
-</span><span id="line-848">                            <span class="n">is_label_image</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
-</span><span id="line-849">                            <span class="n">tree_positions</span><span class="o">=</span><span class="n">current_tree_positions</span><span class="p">,</span>
-</span><span id="line-850">                        <span class="p">)</span>
-</span><span id="line-851">
-</span><span id="line-852">                        <span class="n">img_path</span> <span class="o">=</span> <span class="p">(</span>
-</span><span id="line-853">                            <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span><span class="si">}</span><span class="s2">/voronoi_labels_with_border_</span><span class="si">{</span><span class="n">point_cloud_id</span><span class="si">}</span><span class="s2">_&quot;</span>
-</span><span id="line-854">                            <span class="o">+</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">instance_id</span><span class="si">}</span><span class="s2">.png&quot;</span>
-</span><span id="line-855">                        <span class="p">)</span>
-</span><span id="line-856">                        <span class="n">save_tree_map</span><span class="p">(</span>
-</span><span id="line-857">                            <span class="n">voronoi_labels_with_border</span><span class="p">,</span>
-</span><span id="line-858">                            <span class="n">output_path</span><span class="o">=</span><span class="n">img_path</span><span class="p">,</span>
-</span><span id="line-859">                            <span class="n">is_label_image</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
-</span><span id="line-860">                            <span class="n">tree_positions</span><span class="o">=</span><span class="n">current_tree_positions</span><span class="p">,</span>
-</span><span id="line-861">                        <span class="p">)</span>
-</span><span id="line-862">
-</span><span id="line-863">                    <span class="n">voronoi_labels_without_border_remapped</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">voronoi_labels_without_border</span><span class="p">)</span>
-</span><span id="line-864">                    <span class="n">voronoi_labels_with_border_remapped</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">voronoi_labels_with_border</span><span class="p">)</span>
-</span><span id="line-865">                    <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">:</span>
-</span><span id="line-866">                        <span class="n">tree_position</span> <span class="o">=</span> <span class="n">tree_positions_grid</span><span class="p">[</span><span class="n">instance_id</span> <span class="o">-</span> <span class="mi">1</span><span class="p">]</span>
-</span><span id="line-867">                        <span class="n">voronoi_id</span> <span class="o">=</span> <span class="n">voronoi_labels_without_border</span><span class="p">[</span><span class="n">tree_position</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">tree_position</span><span class="p">[</span><span class="mi">1</span><span class="p">]]</span>
-</span><span id="line-868">                        <span class="n">voronoi_labels_without_border_remapped</span><span class="p">[</span><span class="n">voronoi_labels_without_border</span> <span class="o">==</span> <span class="n">voronoi_id</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span>
-</span><span id="line-869">                            <span class="n">instance_id</span>
-</span><span id="line-870">                        <span class="p">)</span>
-</span><span id="line-871">                        <span class="n">voronoi_labels_with_border_remapped</span><span class="p">[</span><span class="n">voronoi_labels_with_border</span> <span class="o">==</span> <span class="n">voronoi_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">instance_id</span>
-</span><span id="line-872">
-</span><span id="line-873">                    <span class="n">watershed_labels_with_border</span><span class="p">[</span><span class="n">neighborhood_mask_with_border</span><span class="p">]</span> <span class="o">=</span> <span class="n">voronoi_labels_with_border_remapped</span><span class="p">[</span>
-</span><span id="line-874">                        <span class="n">neighborhood_mask_with_border</span>
-</span><span id="line-875">                    <span class="p">]</span>
-</span><span id="line-876">                    <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">neighborhood_mask_without_border</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span>
-</span><span id="line-877">                        <span class="n">voronoi_labels_without_border_remapped</span><span class="p">[</span><span class="n">neighborhood_mask_without_border</span><span class="p">]</span>
-</span><span id="line-878">                    <span class="p">)</span>
-</span><span id="line-879">
-</span><span id="line-880">        <span class="k">return</span> <span class="n">watershed_labels_with_border</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span></div>
+</span><span id="line-817">                    <span class="n">current_tree_positions</span> <span class="o">=</span> <span class="n">tree_positions_grid</span><span class="p">[</span><span class="n">neighbor_instance_ids</span> <span class="o">-</span> <span class="mi">1</span><span class="p">]</span>
+</span><span id="line-818">                    <span class="n">voronoi_input</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">uint32</span><span class="p">)</span>
+</span><span id="line-819">
+</span><span id="line-820">                    <span class="n">voronoi_input</span><span class="p">[</span><span class="n">current_tree_positions</span><span class="p">[:,</span> <span class="mi">0</span><span class="p">],</span> <span class="n">current_tree_positions</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]]</span> <span class="o">=</span> <span class="n">neighbor_instance_ids</span>
+</span><span id="line-821">
+</span><span id="line-822">                    <span class="c1"># when all pixels are assigned the same height value, the Watershed algorithm approximates a Voronoi</span>
+</span><span id="line-823">                    <span class="c1"># segmentation</span>
+</span><span id="line-824">                    <span class="n">voronoi_labels_with_border</span> <span class="o">=</span> <span class="n">watershed</span><span class="p">(</span>
+</span><span id="line-825">                        <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">voronoi_input</span><span class="p">),</span>
+</span><span id="line-826">                        <span class="n">voronoi_input</span><span class="p">,</span>
+</span><span id="line-827">                        <span class="n">mask</span><span class="o">=</span><span class="n">neighborhood_mask_with_border</span><span class="p">,</span>
+</span><span id="line-828">                        <span class="n">watershed_line</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="line-829">                    <span class="p">)</span>
+</span><span id="line-830">                    <span class="n">border_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">voronoi_labels_with_border</span> <span class="o">==</span> <span class="mi">0</span><span class="p">,</span> <span class="n">neighborhood_mask_with_border</span><span class="p">)</span>
+</span><span id="line-831">                    <span class="n">voronoi_labels_without_border</span> <span class="o">=</span> <span class="n">voronoi_labels_with_border</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
+</span><span id="line-832">                    <span class="n">voronoi_labels_without_border</span><span class="p">[</span><span class="n">border_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">voronoi_labels_with_border</span><span class="p">,</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">))[</span>
+</span><span id="line-833">                        <span class="n">border_mask</span>
+</span><span id="line-834">                    <span class="p">]</span>
+</span><span id="line-835">
+</span><span id="line-836">                    <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="ow">and</span> <span class="n">point_cloud_id</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="line-837">                        <span class="n">img_path</span> <span class="o">=</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span><span class="si">}</span><span class="s2">/voronoi_input_</span><span class="si">{</span><span class="n">point_cloud_id</span><span class="si">}</span><span class="s2">_</span><span class="si">{</span><span class="n">instance_id</span><span class="si">}</span><span class="s2">.png&quot;</span>
+</span><span id="line-838">                        <span class="n">save_tree_map</span><span class="p">(</span>
+</span><span id="line-839">                            <span class="n">voronoi_input</span><span class="p">,</span>
+</span><span id="line-840">                            <span class="n">output_path</span><span class="o">=</span><span class="n">img_path</span><span class="p">,</span>
+</span><span id="line-841">                            <span class="n">is_label_image</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="line-842">                        <span class="p">)</span>
+</span><span id="line-843">
+</span><span id="line-844">                        <span class="n">img_path</span> <span class="o">=</span> <span class="p">(</span>
+</span><span id="line-845">                            <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span><span class="si">}</span><span class="s2">/voronoi_labels_without_border_</span><span class="si">{</span><span class="n">point_cloud_id</span><span class="si">}</span><span class="s2">_&quot;</span>
+</span><span id="line-846">                            <span class="o">+</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">instance_id</span><span class="si">}</span><span class="s2">.png&quot;</span>
+</span><span id="line-847">                        <span class="p">)</span>
+</span><span id="line-848">                        <span class="n">save_tree_map</span><span class="p">(</span>
+</span><span id="line-849">                            <span class="n">voronoi_labels_without_border</span><span class="p">,</span>
+</span><span id="line-850">                            <span class="n">output_path</span><span class="o">=</span><span class="n">img_path</span><span class="p">,</span>
+</span><span id="line-851">                            <span class="n">is_label_image</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="line-852">                            <span class="n">tree_positions</span><span class="o">=</span><span class="n">current_tree_positions</span><span class="p">,</span>
+</span><span id="line-853">                        <span class="p">)</span>
+</span><span id="line-854">
+</span><span id="line-855">                        <span class="n">img_path</span> <span class="o">=</span> <span class="p">(</span>
+</span><span id="line-856">                            <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">_visualization_folder</span><span class="si">}</span><span class="s2">/voronoi_labels_with_border_</span><span class="si">{</span><span class="n">point_cloud_id</span><span class="si">}</span><span class="s2">_&quot;</span>
+</span><span id="line-857">                            <span class="o">+</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="n">instance_id</span><span class="si">}</span><span class="s2">.png&quot;</span>
+</span><span id="line-858">                        <span class="p">)</span>
+</span><span id="line-859">                        <span class="n">save_tree_map</span><span class="p">(</span>
+</span><span id="line-860">                            <span class="n">voronoi_labels_with_border</span><span class="p">,</span>
+</span><span id="line-861">                            <span class="n">output_path</span><span class="o">=</span><span class="n">img_path</span><span class="p">,</span>
+</span><span id="line-862">                            <span class="n">is_label_image</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="line-863">                            <span class="n">tree_positions</span><span class="o">=</span><span class="n">current_tree_positions</span><span class="p">,</span>
+</span><span id="line-864">                        <span class="p">)</span>
+</span><span id="line-865">
+</span><span id="line-866">                    <span class="n">voronoi_labels_without_border_remapped</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">voronoi_labels_without_border</span><span class="p">)</span>
+</span><span id="line-867">                    <span class="n">voronoi_labels_with_border_remapped</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros_like</span><span class="p">(</span><span class="n">voronoi_labels_with_border</span><span class="p">)</span>
+</span><span id="line-868">                    <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">:</span>
+</span><span id="line-869">                        <span class="n">tree_position</span> <span class="o">=</span> <span class="n">tree_positions_grid</span><span class="p">[</span><span class="n">instance_id</span> <span class="o">-</span> <span class="mi">1</span><span class="p">]</span>
+</span><span id="line-870">                        <span class="n">voronoi_id</span> <span class="o">=</span> <span class="n">voronoi_labels_without_border</span><span class="p">[</span><span class="n">tree_position</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">tree_position</span><span class="p">[</span><span class="mi">1</span><span class="p">]]</span>
+</span><span id="line-871">                        <span class="n">voronoi_labels_without_border_remapped</span><span class="p">[</span><span class="n">voronoi_labels_without_border</span> <span class="o">==</span> <span class="n">voronoi_id</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span>
+</span><span id="line-872">                            <span class="n">instance_id</span>
+</span><span id="line-873">                        <span class="p">)</span>
+</span><span id="line-874">                        <span class="n">voronoi_labels_with_border_remapped</span><span class="p">[</span><span class="n">voronoi_labels_with_border</span> <span class="o">==</span> <span class="n">voronoi_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">instance_id</span>
+</span><span id="line-875">
+</span><span id="line-876">                    <span class="n">watershed_labels_with_border</span><span class="p">[</span><span class="n">neighborhood_mask_with_border</span><span class="p">]</span> <span class="o">=</span> <span class="n">voronoi_labels_with_border_remapped</span><span class="p">[</span>
+</span><span id="line-877">                        <span class="n">neighborhood_mask_with_border</span>
+</span><span id="line-878">                    <span class="p">]</span>
+</span><span id="line-879">                    <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">neighborhood_mask_without_border</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span>
+</span><span id="line-880">                        <span class="n">voronoi_labels_without_border_remapped</span><span class="p">[</span><span class="n">neighborhood_mask_without_border</span><span class="p">]</span>
+</span><span id="line-881">                    <span class="p">)</span>
+</span><span id="line-882">
+</span><span id="line-883">        <span class="k">return</span> <span class="n">watershed_labels_with_border</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span></div>
 
-</span><span id="line-881">
+</span><span id="line-884">
 <div class="viewcode-block" id="MultiStageAlgorithm.determine_overlapping_crowns">
 <a class="viewcode-back" href="../../../pointtree.instance_segmentation.html#pointtree.instance_segmentation.MultiStageAlgorithm.determine_overlapping_crowns">[docs]</a>
-</span><span id="line-882">    <span class="k">def</span> <span class="nf">determine_overlapping_crowns</span><span class="p">(</span>  <span class="c1"># pylint: disable=too-many-locals</span>
-</span><span id="line-883">        <span class="bp">self</span><span class="p">,</span>
-</span><span id="line-884">        <span class="n">tree_coords</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-885">        <span class="n">classification</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-886">        <span class="n">instance_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-887">        <span class="n">unique_instance_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-888">        <span class="n">canopy_height_model</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-889">        <span class="n">watershed_labels_with_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-890">        <span class="n">watershed_labels_without_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-891">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">]:</span>
-</span><span id="line-892"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
-</span><span id="line-893"><span class="sd">        Identifies trees whose crowns overlap with neighboring trees. If such trees have sufficient point density and</span>
-</span><span id="line-894"><span class="sd">        contain trunk points, their segmentation is refined. For this purpose, the trunk points are selected as seed</span>
-</span><span id="line-895"><span class="sd">        points for region growing and the instance IDs of the crown points are reset to -1.</span>
-</span><span id="line-896">
-</span><span id="line-897">
-</span><span id="line-898"><span class="sd">        Args:</span>
-</span><span id="line-899"><span class="sd">            tree_coords: Coordinates of all tree points.</span>
-</span><span id="line-900"><span class="sd">            classification: Class ID of all tree points.</span>
-</span><span id="line-901"><span class="sd">            instance_ids: Instance IDs of each tree point.</span>
-</span><span id="line-902"><span class="sd">            unique_instance_ids: Unique instance IDs.</span>
-</span><span id="line-903"><span class="sd">            canopy_height_model: The canopy height model.</span>
-</span><span id="line-904"><span class="sd">            watershed_labels_with_border: Watershed labels with boundary lines between neighboring</span>
-</span><span id="line-905"><span class="sd">                trees are assigned the background value of 0.</span>
-</span><span id="line-906">
-</span><span id="line-907"><span class="sd">        Returns:</span>
-</span><span id="line-908"><span class="sd">            Tuple of two arrays. The first contains a boolean mask indicating which points were selected as seed points</span>
-</span><span id="line-909"><span class="sd">                for region growing. The second contains the updated instance IDs for each tree points. For trees whose</span>
-</span><span id="line-910"><span class="sd">                segmentation is to be refined the instance IDs of the crown points is set to -1.</span>
-</span><span id="line-911">
-</span><span id="line-912"><span class="sd">        Shape:</span>
-</span><span id="line-913"><span class="sd">            - :code:`tree_coords`: :math:`(N, 3)`</span>
-</span><span id="line-914"><span class="sd">            - :code:`classification`: :math:`(N)`</span>
-</span><span id="line-915"><span class="sd">            - :code:`instance_ids`: :math:`(N)`</span>
-</span><span id="line-916"><span class="sd">            - :code:`unique_instance_ids`: :math:`(I)`</span>
-</span><span id="line-917"><span class="sd">            - :code:`canopy_height_model`: :math:`(W, H)`</span>
-</span><span id="line-918"><span class="sd">            - :code:`watershed_labels_with_border`: :math:`(W, H)`</span>
-</span><span id="line-919"><span class="sd">            - Output: Tuple of two arrays. Both have shape :math:`(N)`.</span>
-</span><span id="line-920">
-</span><span id="line-921"><span class="sd">            | where</span>
-</span><span id="line-922"><span class="sd">            |</span>
-</span><span id="line-923"><span class="sd">            | :math:`N = \text{ number of tree points}`</span>
-</span><span id="line-924"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
-</span><span id="line-925"><span class="sd">            | :math:`W = \text{ extent of the canopy height model in x-direction}`</span>
-</span><span id="line-926"><span class="sd">            | :math:`H = \text{ extent of the canopy height model in y-direction}`</span>
-</span><span id="line-927"><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="line-928">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Seed Mask computation&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
-</span><span id="line-929">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Compute region growing masks...&quot;</span><span class="p">)</span>
-</span><span id="line-930">            <span class="n">foreground_mask</span> <span class="o">=</span> <span class="n">canopy_height_model</span> <span class="o">&gt;</span> <span class="mi">0</span>
-</span><span id="line-931">
-</span><span id="line-932">            <span class="n">watershed_labels_for_erosion</span> <span class="o">=</span> <span class="n">watershed_labels_with_border</span> <span class="o">+</span> <span class="mi">1</span>
-</span><span id="line-933">            <span class="n">watershed_labels_for_erosion</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">watershed_labels_for_erosion</span> <span class="o">==</span> <span class="mi">1</span><span class="p">,</span> <span class="n">foreground_mask</span><span class="p">)]</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="line-885">    <span class="k">def</span> <span class="nf">determine_overlapping_crowns</span><span class="p">(</span>  <span class="c1"># pylint: disable=too-many-locals</span>
+</span><span id="line-886">        <span class="bp">self</span><span class="p">,</span>
+</span><span id="line-887">        <span class="n">tree_coords</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-888">        <span class="n">classification</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-889">        <span class="n">instance_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-890">        <span class="n">unique_instance_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-891">        <span class="n">canopy_height_model</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-892">        <span class="n">watershed_labels_with_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-893">        <span class="n">watershed_labels_without_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-894">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Tuple</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">]:</span>
+</span><span id="line-895"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="line-896"><span class="sd">        Identifies trees whose crowns overlap with neighboring trees. If such trees have sufficient point density and</span>
+</span><span id="line-897"><span class="sd">        contain trunk points, their segmentation is refined. For this purpose, the trunk points are selected as seed</span>
+</span><span id="line-898"><span class="sd">        points for region growing and the instance IDs of the crown points are reset to -1.</span>
+</span><span id="line-899">
+</span><span id="line-900">
+</span><span id="line-901"><span class="sd">        Args:</span>
+</span><span id="line-902"><span class="sd">            tree_coords: Coordinates of all tree points.</span>
+</span><span id="line-903"><span class="sd">            classification: Class ID of all tree points.</span>
+</span><span id="line-904"><span class="sd">            instance_ids: Instance IDs of each tree point.</span>
+</span><span id="line-905"><span class="sd">            unique_instance_ids: Unique instance IDs.</span>
+</span><span id="line-906"><span class="sd">            canopy_height_model: The canopy height model.</span>
+</span><span id="line-907"><span class="sd">            watershed_labels_with_border: Watershed labels with boundary lines between neighboring</span>
+</span><span id="line-908"><span class="sd">                trees are assigned the background value of 0.</span>
+</span><span id="line-909">
+</span><span id="line-910"><span class="sd">        Returns:</span>
+</span><span id="line-911"><span class="sd">            Tuple of two arrays. The first contains a boolean mask indicating which points were selected as seed points</span>
+</span><span id="line-912"><span class="sd">                for region growing. The second contains the updated instance IDs for each tree points. For trees whose</span>
+</span><span id="line-913"><span class="sd">                segmentation is to be refined the instance IDs of the crown points is set to -1.</span>
+</span><span id="line-914">
+</span><span id="line-915"><span class="sd">        Shape:</span>
+</span><span id="line-916"><span class="sd">            - :code:`tree_coords`: :math:`(N, 3)`</span>
+</span><span id="line-917"><span class="sd">            - :code:`classification`: :math:`(N)`</span>
+</span><span id="line-918"><span class="sd">            - :code:`instance_ids`: :math:`(N)`</span>
+</span><span id="line-919"><span class="sd">            - :code:`unique_instance_ids`: :math:`(I)`</span>
+</span><span id="line-920"><span class="sd">            - :code:`canopy_height_model`: :math:`(W, H)`</span>
+</span><span id="line-921"><span class="sd">            - :code:`watershed_labels_with_border`: :math:`(W, H)`</span>
+</span><span id="line-922"><span class="sd">            - Output: Tuple of two arrays. Both have shape :math:`(N)`.</span>
+</span><span id="line-923">
+</span><span id="line-924"><span class="sd">            | where</span>
+</span><span id="line-925"><span class="sd">            |</span>
+</span><span id="line-926"><span class="sd">            | :math:`N = \text{ number of tree points}`</span>
+</span><span id="line-927"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
+</span><span id="line-928"><span class="sd">            | :math:`W = \text{ extent of the canopy height model in x-direction}`</span>
+</span><span id="line-929"><span class="sd">            | :math:`H = \text{ extent of the canopy height model in y-direction}`</span>
+</span><span id="line-930"><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="line-931">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Seed Mask computation&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
+</span><span id="line-932">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Compute region growing masks...&quot;</span><span class="p">)</span>
+</span><span id="line-933">            <span class="n">foreground_mask</span> <span class="o">=</span> <span class="n">canopy_height_model</span> <span class="o">&gt;</span> <span class="mi">0</span>
 </span><span id="line-934">
-</span><span id="line-935">            <span class="n">eroded_watershed_labels</span> <span class="o">=</span> <span class="n">erosion</span><span class="p">(</span><span class="n">watershed_labels_for_erosion</span><span class="p">,</span> <span class="n">disk</span><span class="p">(</span><span class="mi">1</span><span class="p">))</span>
-</span><span id="line-936">            <span class="n">mask_background_erosion</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">foreground_mask</span><span class="p">,</span> <span class="n">eroded_watershed_labels</span> <span class="o">==</span> <span class="mi">1</span><span class="p">)</span>
-</span><span id="line-937">            <span class="n">eroded_watershed_labels</span><span class="p">[</span><span class="n">mask_background_erosion</span><span class="p">]</span> <span class="o">=</span> <span class="n">watershed_labels_for_erosion</span><span class="p">[</span><span class="n">mask_background_erosion</span><span class="p">]</span>
-</span><span id="line-938">
-</span><span id="line-939">            <span class="n">kd_tree</span> <span class="o">=</span> <span class="n">KDTree</span><span class="p">(</span><span class="n">tree_coords</span><span class="p">)</span>
-</span><span id="line-940">
-</span><span id="line-941">            <span class="n">neighbor_distances</span> <span class="o">=</span> <span class="n">kd_tree</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">tree_coords</span><span class="p">,</span> <span class="n">k</span><span class="o">=</span><span class="mi">2</span><span class="p">)[</span><span class="mi">0</span><span class="p">]</span>
-</span><span id="line-942">            <span class="n">neighbor_distances</span> <span class="o">=</span> <span class="n">neighbor_distances</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]</span><span class="o">.</span><span class="n">flatten</span><span class="p">()</span>
+</span><span id="line-935">            <span class="n">watershed_labels_for_erosion</span> <span class="o">=</span> <span class="n">watershed_labels_with_border</span> <span class="o">+</span> <span class="mi">1</span>
+</span><span id="line-936">            <span class="n">watershed_labels_for_erosion</span><span class="p">[</span><span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">watershed_labels_for_erosion</span> <span class="o">==</span> <span class="mi">1</span><span class="p">,</span> <span class="n">foreground_mask</span><span class="p">)]</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="line-937">
+</span><span id="line-938">            <span class="n">eroded_watershed_labels</span> <span class="o">=</span> <span class="n">erosion</span><span class="p">(</span><span class="n">watershed_labels_for_erosion</span><span class="p">,</span> <span class="n">disk</span><span class="p">(</span><span class="mi">1</span><span class="p">))</span>
+</span><span id="line-939">            <span class="n">mask_background_erosion</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">foreground_mask</span><span class="p">,</span> <span class="n">eroded_watershed_labels</span> <span class="o">==</span> <span class="mi">1</span><span class="p">)</span>
+</span><span id="line-940">            <span class="n">eroded_watershed_labels</span><span class="p">[</span><span class="n">mask_background_erosion</span><span class="p">]</span> <span class="o">=</span> <span class="n">watershed_labels_for_erosion</span><span class="p">[</span><span class="n">mask_background_erosion</span><span class="p">]</span>
+</span><span id="line-941">
+</span><span id="line-942">            <span class="n">kd_tree</span> <span class="o">=</span> <span class="n">KDTree</span><span class="p">(</span><span class="n">tree_coords</span><span class="p">)</span>
 </span><span id="line-943">
-</span><span id="line-944">            <span class="n">instances_to_refine</span> <span class="o">=</span> <span class="p">[]</span>
-</span><span id="line-945">            <span class="n">average_point_spacings</span> <span class="o">=</span> <span class="p">[]</span>
-</span><span id="line-946">            <span class="n">instance_seed_masks</span> <span class="o">=</span> <span class="p">[]</span>
-</span><span id="line-947">
-</span><span id="line-948">            <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">unique_instance_ids</span><span class="p">:</span>
-</span><span id="line-949">                <span class="n">watershed_mask</span> <span class="o">=</span> <span class="n">watershed_labels_with_border</span> <span class="o">==</span> <span class="n">instance_id</span> <span class="o">+</span> <span class="mi">1</span>
-</span><span id="line-950">                <span class="n">eroded_watershed_mask</span> <span class="o">=</span> <span class="n">eroded_watershed_labels</span> <span class="o">==</span> <span class="n">instance_id</span> <span class="o">+</span> <span class="mi">2</span>
-</span><span id="line-951">
-</span><span id="line-952">                <span class="k">if</span> <span class="p">(</span><span class="n">watershed_mask</span> <span class="o">==</span> <span class="n">eroded_watershed_mask</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
-</span><span id="line-953">                    <span class="c1"># the segmentation is not refined in that case</span>
-</span><span id="line-954">                    <span class="k">continue</span>
-</span><span id="line-955">
-</span><span id="line-956">                <span class="n">instance_mask</span> <span class="o">=</span> <span class="n">instance_ids</span> <span class="o">==</span> <span class="n">instance_id</span>
-</span><span id="line-957">                <span class="n">instance_trunk_mask</span> <span class="o">=</span> <span class="n">classification</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">_trunk_class_id</span>
-</span><span id="line-958">                <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_branch_class_id</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="line-959">                    <span class="n">instance_trunk_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span><span class="n">instance_trunk_mask</span><span class="p">,</span> <span class="n">classification</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">_branch_class_id</span><span class="p">)</span>
-</span><span id="line-960">
-</span><span id="line-961">                <span class="n">instance_trunk_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">instance_trunk_mask</span><span class="p">,</span> <span class="n">instance_mask</span><span class="p">)</span>
-</span><span id="line-962">
-</span><span id="line-963">                <span class="n">average_point_spacing</span> <span class="o">=</span> <span class="n">neighbor_distances</span><span class="p">[</span><span class="n">instance_mask</span><span class="p">]</span><span class="o">.</span><span class="n">mean</span><span class="p">()</span>
-</span><span id="line-964">
-</span><span id="line-965">                <span class="k">if</span> <span class="n">instance_trunk_mask</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="ow">and</span> <span class="n">average_point_spacing</span> <span class="o">&lt;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_max_point_spacing_region_growing</span><span class="p">:</span>
-</span><span id="line-966">                    <span class="n">instances_to_refine</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">instance_id</span><span class="p">)</span>
-</span><span id="line-967">                    <span class="n">average_point_spacings</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">average_point_spacing</span><span class="p">)</span>
-</span><span id="line-968">                    <span class="n">instance_seed_masks</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">instance_trunk_mask</span><span class="p">)</span>
-</span><span id="line-969">
-</span><span id="line-970">            <span class="n">seed_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">tree_coords</span><span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
-</span><span id="line-971">
-</span><span id="line-972">            <span class="k">for</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">average_point_spacing</span><span class="p">,</span> <span class="n">instance_seed_mask</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span>
-</span><span id="line-973">                <span class="n">instances_to_refine</span><span class="p">,</span> <span class="n">average_point_spacings</span><span class="p">,</span> <span class="n">instance_seed_masks</span>
-</span><span id="line-974">            <span class="p">):</span>
-</span><span id="line-975">                <span class="n">instance_mask</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">instance_id</span> <span class="o">+</span> <span class="mi">1</span>
-</span><span id="line-976">                <span class="n">dilated_instance_mask</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">instance_mask</span><span class="p">,</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">))</span>
-</span><span id="line-977">                <span class="n">neighbor_instance_ids</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">dilated_instance_mask</span><span class="p">])</span> <span class="o">-</span> <span class="mi">1</span>
-</span><span id="line-978">
-</span><span id="line-979">                <span class="n">has_neighbor_to_refine</span> <span class="o">=</span> <span class="kc">False</span>
-</span><span id="line-980">                <span class="k">for</span> <span class="n">neighbor_instance_id</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">:</span>
-</span><span id="line-981">                    <span class="k">if</span> <span class="n">neighbor_instance_id</span> <span class="ow">in</span> <span class="p">(</span><span class="n">instance_id</span><span class="p">,</span> <span class="o">-</span><span class="mi">1</span><span class="p">):</span>
-</span><span id="line-982">                        <span class="k">continue</span>
-</span><span id="line-983">                    <span class="k">if</span> <span class="n">neighbor_instance_id</span> <span class="ow">in</span> <span class="n">instances_to_refine</span><span class="p">:</span>
-</span><span id="line-984">                        <span class="n">has_neighbor_to_refine</span> <span class="o">=</span> <span class="kc">True</span>
-</span><span id="line-985">                        <span class="k">break</span>
-</span><span id="line-986">
-</span><span id="line-987">                <span class="k">if</span> <span class="n">has_neighbor_to_refine</span><span class="p">:</span>
-</span><span id="line-988">                    <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
-</span><span id="line-989">                        <span class="s2">&quot;Segmentation of </span><span class="si">%d</span><span class="s2"> will be refined (Average point spacing: </span><span class="si">%.3f</span><span class="s2">)...&quot;</span><span class="p">,</span>
-</span><span id="line-990">                        <span class="n">instance_id</span><span class="p">,</span>
-</span><span id="line-991">                        <span class="n">average_point_spacing</span><span class="p">,</span>
-</span><span id="line-992">                    <span class="p">)</span>
-</span><span id="line-993">                    <span class="n">instance_crown_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
-</span><span id="line-994">                        <span class="n">instance_ids</span> <span class="o">==</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">classification</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">_crown_class_id</span>
+</span><span id="line-944">            <span class="n">neighbor_distances</span> <span class="o">=</span> <span class="n">kd_tree</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">tree_coords</span><span class="p">,</span> <span class="n">k</span><span class="o">=</span><span class="mi">2</span><span class="p">)[</span><span class="mi">0</span><span class="p">]</span>
+</span><span id="line-945">            <span class="n">neighbor_distances</span> <span class="o">=</span> <span class="n">neighbor_distances</span><span class="p">[:,</span> <span class="mi">1</span><span class="p">]</span><span class="o">.</span><span class="n">flatten</span><span class="p">()</span>
+</span><span id="line-946">
+</span><span id="line-947">            <span class="n">instances_to_refine</span> <span class="o">=</span> <span class="p">[]</span>
+</span><span id="line-948">            <span class="n">average_point_spacings</span> <span class="o">=</span> <span class="p">[]</span>
+</span><span id="line-949">            <span class="n">instance_seed_masks</span> <span class="o">=</span> <span class="p">[]</span>
+</span><span id="line-950">
+</span><span id="line-951">            <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">unique_instance_ids</span><span class="p">:</span>
+</span><span id="line-952">                <span class="n">watershed_mask</span> <span class="o">=</span> <span class="n">watershed_labels_with_border</span> <span class="o">==</span> <span class="n">instance_id</span> <span class="o">+</span> <span class="mi">1</span>
+</span><span id="line-953">                <span class="n">eroded_watershed_mask</span> <span class="o">=</span> <span class="n">eroded_watershed_labels</span> <span class="o">==</span> <span class="n">instance_id</span> <span class="o">+</span> <span class="mi">2</span>
+</span><span id="line-954">
+</span><span id="line-955">                <span class="k">if</span> <span class="p">(</span><span class="n">watershed_mask</span> <span class="o">==</span> <span class="n">eroded_watershed_mask</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
+</span><span id="line-956">                    <span class="c1"># the segmentation is not refined in that case</span>
+</span><span id="line-957">                    <span class="k">continue</span>
+</span><span id="line-958">
+</span><span id="line-959">                <span class="n">instance_mask</span> <span class="o">=</span> <span class="n">instance_ids</span> <span class="o">==</span> <span class="n">instance_id</span>
+</span><span id="line-960">                <span class="n">instance_trunk_mask</span> <span class="o">=</span> <span class="n">classification</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">_trunk_class_id</span>
+</span><span id="line-961">                <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">_branch_class_id</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="line-962">                    <span class="n">instance_trunk_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span><span class="n">instance_trunk_mask</span><span class="p">,</span> <span class="n">classification</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">_branch_class_id</span><span class="p">)</span>
+</span><span id="line-963">
+</span><span id="line-964">                <span class="n">instance_trunk_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span><span class="n">instance_trunk_mask</span><span class="p">,</span> <span class="n">instance_mask</span><span class="p">)</span>
+</span><span id="line-965">
+</span><span id="line-966">                <span class="n">average_point_spacing</span> <span class="o">=</span> <span class="n">neighbor_distances</span><span class="p">[</span><span class="n">instance_mask</span><span class="p">]</span><span class="o">.</span><span class="n">mean</span><span class="p">()</span>
+</span><span id="line-967">
+</span><span id="line-968">                <span class="k">if</span> <span class="n">instance_trunk_mask</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="ow">and</span> <span class="n">average_point_spacing</span> <span class="o">&lt;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_max_point_spacing_region_growing</span><span class="p">:</span>
+</span><span id="line-969">                    <span class="n">instances_to_refine</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">instance_id</span><span class="p">)</span>
+</span><span id="line-970">                    <span class="n">average_point_spacings</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">average_point_spacing</span><span class="p">)</span>
+</span><span id="line-971">                    <span class="n">instance_seed_masks</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">instance_trunk_mask</span><span class="p">)</span>
+</span><span id="line-972">
+</span><span id="line-973">            <span class="n">seed_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">tree_coords</span><span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
+</span><span id="line-974">
+</span><span id="line-975">            <span class="k">for</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">average_point_spacing</span><span class="p">,</span> <span class="n">instance_seed_mask</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span>
+</span><span id="line-976">                <span class="n">instances_to_refine</span><span class="p">,</span> <span class="n">average_point_spacings</span><span class="p">,</span> <span class="n">instance_seed_masks</span>
+</span><span id="line-977">            <span class="p">):</span>
+</span><span id="line-978">                <span class="n">instance_mask</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">instance_id</span> <span class="o">+</span> <span class="mi">1</span>
+</span><span id="line-979">                <span class="n">dilated_instance_mask</span> <span class="o">=</span> <span class="n">dilation</span><span class="p">(</span><span class="n">instance_mask</span><span class="p">,</span> <span class="n">rectangle</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">3</span><span class="p">))</span>
+</span><span id="line-980">                <span class="n">neighbor_instance_ids</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">dilated_instance_mask</span><span class="p">])</span> <span class="o">-</span> <span class="mi">1</span>
+</span><span id="line-981">
+</span><span id="line-982">                <span class="n">has_neighbor_to_refine</span> <span class="o">=</span> <span class="kc">False</span>
+</span><span id="line-983">                <span class="k">for</span> <span class="n">neighbor_instance_id</span> <span class="ow">in</span> <span class="n">neighbor_instance_ids</span><span class="p">:</span>
+</span><span id="line-984">                    <span class="k">if</span> <span class="n">neighbor_instance_id</span> <span class="ow">in</span> <span class="p">(</span><span class="n">instance_id</span><span class="p">,</span> <span class="o">-</span><span class="mi">1</span><span class="p">):</span>
+</span><span id="line-985">                        <span class="k">continue</span>
+</span><span id="line-986">                    <span class="k">if</span> <span class="n">neighbor_instance_id</span> <span class="ow">in</span> <span class="n">instances_to_refine</span><span class="p">:</span>
+</span><span id="line-987">                        <span class="n">has_neighbor_to_refine</span> <span class="o">=</span> <span class="kc">True</span>
+</span><span id="line-988">                        <span class="k">break</span>
+</span><span id="line-989">
+</span><span id="line-990">                <span class="k">if</span> <span class="n">has_neighbor_to_refine</span><span class="p">:</span>
+</span><span id="line-991">                    <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span>
+</span><span id="line-992">                        <span class="s2">&quot;Segmentation of </span><span class="si">%d</span><span class="s2"> will be refined (Average point spacing: </span><span class="si">%.3f</span><span class="s2">)...&quot;</span><span class="p">,</span>
+</span><span id="line-993">                        <span class="n">instance_id</span><span class="p">,</span>
+</span><span id="line-994">                        <span class="n">average_point_spacing</span><span class="p">,</span>
 </span><span id="line-995">                    <span class="p">)</span>
-</span><span id="line-996">                    <span class="n">instance_ids</span><span class="p">[</span><span class="n">instance_crown_mask</span><span class="p">]</span> <span class="o">=</span> <span class="o">-</span><span class="mi">1</span>
-</span><span id="line-997">                    <span class="n">seed_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span><span class="n">seed_mask</span><span class="p">,</span> <span class="n">instance_seed_mask</span><span class="p">)</span>
-</span><span id="line-998">
-</span><span id="line-999">        <span class="k">return</span> <span class="n">seed_mask</span><span class="p">,</span> <span class="n">instance_ids</span></div>
+</span><span id="line-996">                    <span class="n">instance_crown_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
+</span><span id="line-997">                        <span class="n">instance_ids</span> <span class="o">==</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">classification</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">_crown_class_id</span>
+</span><span id="line-998">                    <span class="p">)</span>
+</span><span id="line-999">                    <span class="n">instance_ids</span><span class="p">[</span><span class="n">instance_crown_mask</span><span class="p">]</span> <span class="o">=</span> <span class="o">-</span><span class="mi">1</span>
+</span><span id="line-1000">                    <span class="n">seed_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span><span class="n">seed_mask</span><span class="p">,</span> <span class="n">instance_seed_mask</span><span class="p">)</span>
+</span><span id="line-1001">
+</span><span id="line-1002">        <span class="k">return</span> <span class="n">seed_mask</span><span class="p">,</span> <span class="n">instance_ids</span></div>
 
-</span><span id="line-1000">
+</span><span id="line-1003">
 <div class="viewcode-block" id="MultiStageAlgorithm.compute_crown_distance_fields">
 <a class="viewcode-back" href="../../../pointtree.instance_segmentation.html#pointtree.instance_segmentation.MultiStageAlgorithm.compute_crown_distance_fields">[docs]</a>
-</span><span id="line-1001">    <span class="k">def</span> <span class="nf">compute_crown_distance_fields</span><span class="p">(</span>
-</span><span id="line-1002">        <span class="bp">self</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">tree_positions_grid</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span>
-</span><span id="line-1003">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">:</span>
-</span><span id="line-1004"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
-</span><span id="line-1005"><span class="sd">        Calculates signed distance fields from the 2D segmentation mask of each tree. The distance values specify the 2D</span>
-</span><span id="line-1006"><span class="sd">        distance to the boundary of the segmentation mask. The distance value is negative for pixels that belong to the</span>
-</span><span id="line-1007"><span class="sd">        tree and positive for pixels that do not belong to the tree.</span>
-</span><span id="line-1008">
-</span><span id="line-1009"><span class="sd">        Args:</span>
-</span><span id="line-1010"><span class="sd">            watershed_labels_without_border: Watershed labels without boundary lines.</span>
-</span><span id="line-1011"><span class="sd">            tree_positions_grid: Indices of the grid cells of the canopy height model in which the tree positions are</span>
-</span><span id="line-1012"><span class="sd">                located.</span>
-</span><span id="line-1013">
-</span><span id="line-1014"><span class="sd">        Returns:</span>
-</span><span id="line-1015"><span class="sd">            Signed distance masks for all trees.</span>
+</span><span id="line-1004">    <span class="k">def</span> <span class="nf">compute_crown_distance_fields</span><span class="p">(</span>
+</span><span id="line-1005">        <span class="bp">self</span><span class="p">,</span> <span class="n">watershed_labels_without_border</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">tree_positions_grid</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span>
+</span><span id="line-1006">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">:</span>
+</span><span id="line-1007"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="line-1008"><span class="sd">        Calculates signed distance fields from the 2D segmentation mask of each tree. The distance values specify the 2D</span>
+</span><span id="line-1009"><span class="sd">        distance to the boundary of the segmentation mask. The distance value is negative for pixels that belong to the</span>
+</span><span id="line-1010"><span class="sd">        tree and positive for pixels that do not belong to the tree.</span>
+</span><span id="line-1011">
+</span><span id="line-1012"><span class="sd">        Args:</span>
+</span><span id="line-1013"><span class="sd">            watershed_labels_without_border: Watershed labels without boundary lines.</span>
+</span><span id="line-1014"><span class="sd">            tree_positions_grid: Indices of the grid cells of the canopy height model in which the tree positions are</span>
+</span><span id="line-1015"><span class="sd">                located.</span>
 </span><span id="line-1016">
-</span><span id="line-1017"><span class="sd">        Shape:</span>
-</span><span id="line-1018"><span class="sd">            - :code:`watershed_labels_without_border`: :math:`(W, H)`</span>
-</span><span id="line-1019"><span class="sd">            - :code:`tree_positions_grid`: :math:`(N, 2)`</span>
-</span><span id="line-1020"><span class="sd">            - Output: :math:`(I, W, H)`.</span>
-</span><span id="line-1021">
-</span><span id="line-1022"><span class="sd">            | where</span>
-</span><span id="line-1023"><span class="sd">            |</span>
-</span><span id="line-1024"><span class="sd">            | :math:`N = \text{ number of tree points}`</span>
-</span><span id="line-1025"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
-</span><span id="line-1026"><span class="sd">            | :math:`W = \text{ extent of the distance fields in x-direction}`</span>
-</span><span id="line-1027"><span class="sd">            | :math:`H = \text{ extent of the distance fields in y-direction}`</span>
-</span><span id="line-1028"><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="line-1029">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Computation of crown distance fields&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
-</span><span id="line-1030">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Compute crown distance fields...&quot;</span><span class="p">)</span>
-</span><span id="line-1031">            <span class="n">crown_distance_fields</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">empty</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">tree_positions_grid</span><span class="p">),</span> <span class="o">*</span><span class="n">watershed_labels_without_border</span><span class="o">.</span><span class="n">shape</span><span class="p">))</span>
-</span><span id="line-1032">            <span class="k">for</span> <span class="n">idx</span><span class="p">,</span> <span class="n">tree_position</span> <span class="ow">in</span> <span class="nb">enumerate</span><span class="p">(</span><span class="n">tree_positions_grid</span><span class="p">):</span>
-</span><span id="line-1033">                <span class="n">instance_id</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">tree_position</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">tree_position</span><span class="p">[</span><span class="mi">1</span><span class="p">]]</span>
-</span><span id="line-1034">                <span class="n">mask</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">instance_id</span>
-</span><span id="line-1035">                <span class="n">inverse_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_not</span><span class="p">(</span><span class="n">mask</span><span class="p">)</span>
-</span><span id="line-1036">                <span class="n">distance_mask</span> <span class="o">=</span> <span class="o">-</span><span class="n">cast</span><span class="p">(</span>  <span class="c1"># pylint: disable=invalid-unary-operand-type</span>
-</span><span id="line-1037">                    <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">ndi</span><span class="o">.</span><span class="n">distance_transform_edt</span><span class="p">(</span><span class="n">mask</span><span class="p">)</span>
-</span><span id="line-1038">                <span class="p">)</span>
-</span><span id="line-1039">                <span class="n">distance_mask</span><span class="p">[</span><span class="n">inverse_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">ndi</span><span class="o">.</span><span class="n">distance_transform_edt</span><span class="p">(</span><span class="n">inverse_mask</span><span class="p">)[</span><span class="n">inverse_mask</span><span class="p">]</span>
-</span><span id="line-1040">                <span class="n">crown_distance_fields</span><span class="p">[</span><span class="n">idx</span><span class="p">]</span> <span class="o">=</span> <span class="n">distance_mask</span>
-</span><span id="line-1041">
-</span><span id="line-1042">        <span class="k">return</span> <span class="n">crown_distance_fields</span></div>
+</span><span id="line-1017"><span class="sd">        Returns:</span>
+</span><span id="line-1018"><span class="sd">            Signed distance masks for all trees.</span>
+</span><span id="line-1019">
+</span><span id="line-1020"><span class="sd">        Shape:</span>
+</span><span id="line-1021"><span class="sd">            - :code:`watershed_labels_without_border`: :math:`(W, H)`</span>
+</span><span id="line-1022"><span class="sd">            - :code:`tree_positions_grid`: :math:`(N, 2)`</span>
+</span><span id="line-1023"><span class="sd">            - Output: :math:`(I, W, H)`.</span>
+</span><span id="line-1024">
+</span><span id="line-1025"><span class="sd">            | where</span>
+</span><span id="line-1026"><span class="sd">            |</span>
+</span><span id="line-1027"><span class="sd">            | :math:`N = \text{ number of tree points}`</span>
+</span><span id="line-1028"><span class="sd">            | :math:`I = \text{ number of tree instances}`</span>
+</span><span id="line-1029"><span class="sd">            | :math:`W = \text{ extent of the distance fields in x-direction}`</span>
+</span><span id="line-1030"><span class="sd">            | :math:`H = \text{ extent of the distance fields in y-direction}`</span>
+</span><span id="line-1031"><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="line-1032">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Computation of crown distance fields&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
+</span><span id="line-1033">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Compute crown distance fields...&quot;</span><span class="p">)</span>
+</span><span id="line-1034">            <span class="n">crown_distance_fields</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">empty</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">tree_positions_grid</span><span class="p">),</span> <span class="o">*</span><span class="n">watershed_labels_without_border</span><span class="o">.</span><span class="n">shape</span><span class="p">))</span>
+</span><span id="line-1035">            <span class="k">for</span> <span class="n">idx</span><span class="p">,</span> <span class="n">tree_position</span> <span class="ow">in</span> <span class="nb">enumerate</span><span class="p">(</span><span class="n">tree_positions_grid</span><span class="p">):</span>
+</span><span id="line-1036">                <span class="n">instance_id</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span><span class="p">[</span><span class="n">tree_position</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">tree_position</span><span class="p">[</span><span class="mi">1</span><span class="p">]]</span>
+</span><span id="line-1037">                <span class="n">mask</span> <span class="o">=</span> <span class="n">watershed_labels_without_border</span> <span class="o">==</span> <span class="n">instance_id</span>
+</span><span id="line-1038">                <span class="n">inverse_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_not</span><span class="p">(</span><span class="n">mask</span><span class="p">)</span>
+</span><span id="line-1039">                <span class="n">distance_mask</span> <span class="o">=</span> <span class="o">-</span><span class="n">cast</span><span class="p">(</span>  <span class="c1"># pylint: disable=invalid-unary-operand-type</span>
+</span><span id="line-1040">                    <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span> <span class="n">ndi</span><span class="o">.</span><span class="n">distance_transform_edt</span><span class="p">(</span><span class="n">mask</span><span class="p">)</span>
+</span><span id="line-1041">                <span class="p">)</span>
+</span><span id="line-1042">                <span class="n">distance_mask</span><span class="p">[</span><span class="n">inverse_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">ndi</span><span class="o">.</span><span class="n">distance_transform_edt</span><span class="p">(</span><span class="n">inverse_mask</span><span class="p">)[</span><span class="n">inverse_mask</span><span class="p">]</span>
+</span><span id="line-1043">                <span class="n">crown_distance_fields</span><span class="p">[</span><span class="n">idx</span><span class="p">]</span> <span class="o">=</span> <span class="n">distance_mask</span>
+</span><span id="line-1044">
+</span><span id="line-1045">        <span class="k">return</span> <span class="n">crown_distance_fields</span></div>
 
-</span><span id="line-1043">
+</span><span id="line-1046">
 <div class="viewcode-block" id="MultiStageAlgorithm.grow_trees">
 <a class="viewcode-back" href="../../../pointtree.instance_segmentation.html#pointtree.instance_segmentation.MultiStageAlgorithm.grow_trees">[docs]</a>
-</span><span id="line-1044">    <span class="k">def</span> <span class="nf">grow_trees</span><span class="p">(</span>  <span class="c1"># pylint: disable=too-many-locals</span>
-</span><span id="line-1045">        <span class="bp">self</span><span class="p">,</span>
-</span><span id="line-1046">        <span class="n">tree_coords</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-1047">        <span class="n">instance_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-1048">        <span class="n">unique_instances_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-1049">        <span class="n">grid_origin</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-1050">        <span class="n">crown_distance_fields</span><span class="p">,</span>
-</span><span id="line-1051">        <span class="n">seed_mask</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
-</span><span id="line-1052">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">:</span>
-</span><span id="line-1053"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
-</span><span id="line-1054"><span class="sd">        Region growing segmentation.</span>
-</span><span id="line-1055">
-</span><span id="line-1056"><span class="sd">        Args:</span>
-</span><span id="line-1057"><span class="sd">            tree_coords: Coordinates of all tree points.</span>
-</span><span id="line-1058"><span class="sd">            instance_ids: Instance IDs of each tree point.</span>
-</span><span id="line-1059"><span class="sd">            grid_origin: 2D coordinates of the origin of the crown distance fields.</span>
-</span><span id="line-1060"><span class="sd">            crown_distance_fields: 2D signed distance fields idicating the distance to the crown boundary of each tree</span>
-</span><span id="line-1061"><span class="sd">                to segment.</span>
-</span><span id="line-1062"><span class="sd">            seed_mask: Boolean mask indicating which points were selected as seed points for region growing.</span>
-</span><span id="line-1063">
-</span><span id="line-1064"><span class="sd">        Returns:</span>
-</span><span id="line-1065"><span class="sd">            Updated instance IDs.</span>
+</span><span id="line-1047">    <span class="k">def</span> <span class="nf">grow_trees</span><span class="p">(</span>  <span class="c1"># pylint: disable=too-many-locals</span>
+</span><span id="line-1048">        <span class="bp">self</span><span class="p">,</span>
+</span><span id="line-1049">        <span class="n">tree_coords</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-1050">        <span class="n">instance_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-1051">        <span class="n">unique_instances_ids</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-1052">        <span class="n">grid_origin</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-1053">        <span class="n">crown_distance_fields</span><span class="p">,</span>
+</span><span id="line-1054">        <span class="n">seed_mask</span><span class="p">:</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">,</span>
+</span><span id="line-1055">    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">np</span><span class="o">.</span><span class="n">ndarray</span><span class="p">:</span>
+</span><span id="line-1056"><span class="w">        </span><span class="sa">r</span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="line-1057"><span class="sd">        Region growing segmentation.</span>
+</span><span id="line-1058">
+</span><span id="line-1059"><span class="sd">        Args:</span>
+</span><span id="line-1060"><span class="sd">            tree_coords: Coordinates of all tree points.</span>
+</span><span id="line-1061"><span class="sd">            instance_ids: Instance IDs of each tree point.</span>
+</span><span id="line-1062"><span class="sd">            grid_origin: 2D coordinates of the origin of the crown distance fields.</span>
+</span><span id="line-1063"><span class="sd">            crown_distance_fields: 2D signed distance fields idicating the distance to the crown boundary of each tree</span>
+</span><span id="line-1064"><span class="sd">                to segment.</span>
+</span><span id="line-1065"><span class="sd">            seed_mask: Boolean mask indicating which points were selected as seed points for region growing.</span>
 </span><span id="line-1066">
-</span><span id="line-1067"><span class="sd">        Shape:</span>
-</span><span id="line-1068"><span class="sd">            - :code:`tree_coords`: :math:`(N, 3)`</span>
-</span><span id="line-1069"><span class="sd">            - :code:`instance_ids`: :math:`(N)`</span>
-</span><span id="line-1070"><span class="sd">            - :code:`grid_origin`: :math:`(2)`</span>
-</span><span id="line-1071"><span class="sd">            - :code:`crown_distance_fields`: :math:`(I&#39;, W, H)`</span>
-</span><span id="line-1072"><span class="sd">            - :code:`seed_mask`: :math:`(N)`</span>
-</span><span id="line-1073"><span class="sd">            - Output: :math:`(N)`.</span>
-</span><span id="line-1074">
-</span><span id="line-1075"><span class="sd">            | where</span>
-</span><span id="line-1076"><span class="sd">            |</span>
-</span><span id="line-1077"><span class="sd">            | :math:`N = \text{ number of tree points}`</span>
-</span><span id="line-1078"><span class="sd">            | :math:`I&#39; = \text{ number of tree instances to segment}`</span>
-</span><span id="line-1079"><span class="sd">            | :math:`W = \text{ extent of the distance fields in x-direction}`</span>
-</span><span id="line-1080"><span class="sd">            | :math:`H = \text{ extent of the distance fields in y-direction}`</span>
-</span><span id="line-1081">
-</span><span id="line-1082"><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="line-1083">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Region growing&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
-</span><span id="line-1084">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Region growing...&quot;</span><span class="p">)</span>
-</span><span id="line-1085">            <span class="k">if</span> <span class="n">seed_mask</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-</span><span id="line-1086">                <span class="k">return</span> <span class="n">instance_ids</span>
-</span><span id="line-1087">
-</span><span id="line-1088">            <span class="n">growing_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span><span class="n">instance_ids</span> <span class="o">==</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="n">seed_mask</span><span class="p">)</span>
-</span><span id="line-1089">            <span class="n">growing_points</span> <span class="o">=</span> <span class="n">tree_coords</span><span class="p">[</span><span class="n">growing_mask</span><span class="p">]</span>
-</span><span id="line-1090">            <span class="n">growing_points</span><span class="p">[:,</span> <span class="mi">2</span><span class="p">]</span> <span class="o">*=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_z_scale</span>
-</span><span id="line-1091">            <span class="n">growing_instance_ids</span> <span class="o">=</span> <span class="n">instance_ids</span><span class="p">[</span><span class="n">growing_mask</span><span class="p">]</span>
-</span><span id="line-1092">            <span class="n">growing_seed_mask</span> <span class="o">=</span> <span class="n">growing_instance_ids</span> <span class="o">!=</span> <span class="o">-</span><span class="mi">1</span>
-</span><span id="line-1093">
-</span><span id="line-1094">            <span class="c1"># the region growing is only executed for certain trees</span>
-</span><span id="line-1095">            <span class="c1"># the following code maps the instance IDs of the trees for which region growing is executed to a</span>
-</span><span id="line-1096">            <span class="c1"># continuous range</span>
-</span><span id="line-1097">            <span class="n">instance_id_mapping</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">full</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">unique_instances_ids</span><span class="p">),</span> <span class="n">fill_value</span><span class="o">=-</span><span class="mi">1</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
-</span><span id="line-1098">            <span class="n">inverse_instance_id_mapping</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">full</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">crown_distance_fields</span><span class="p">),</span> <span class="n">fill_value</span><span class="o">=-</span><span class="mi">1</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
-</span><span id="line-1099">
-</span><span id="line-1100">            <span class="n">region_growing_instance_ids</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">instance_ids</span><span class="p">[</span><span class="n">seed_mask</span><span class="p">])</span>
-</span><span id="line-1101">
-</span><span id="line-1102">            <span class="n">remapped_id</span> <span class="o">=</span> <span class="mi">0</span>
-</span><span id="line-1103">            <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">unique_instances_ids</span><span class="p">:</span>
-</span><span id="line-1104">                <span class="k">if</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">region_growing_instance_ids</span><span class="p">:</span>
-</span><span id="line-1105">                    <span class="n">instance_id_mapping</span><span class="p">[</span><span class="n">instance_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">remapped_id</span>
-</span><span id="line-1106">                    <span class="n">inverse_instance_id_mapping</span><span class="p">[</span><span class="n">remapped_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">instance_id</span>
-</span><span id="line-1107">                    <span class="n">remapped_id</span> <span class="o">+=</span> <span class="mi">1</span>
-</span><span id="line-1108">
-</span><span id="line-1109">            <span class="n">point_indices</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">growing_points</span><span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
-</span><span id="line-1110">
-</span><span id="line-1111">            <span class="n">kd_tree</span> <span class="o">=</span> <span class="n">KDTree</span><span class="p">(</span><span class="n">growing_points</span><span class="p">)</span>
-</span><span id="line-1112">            <span class="n">neighbor_dists</span><span class="p">,</span> <span class="n">neighbor_indices</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">kd_tree</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">growing_points</span><span class="p">,</span> <span class="n">k</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">_num_neighbors_region_growing</span><span class="p">)</span>
+</span><span id="line-1067"><span class="sd">        Returns:</span>
+</span><span id="line-1068"><span class="sd">            Updated instance IDs.</span>
+</span><span id="line-1069">
+</span><span id="line-1070"><span class="sd">        Shape:</span>
+</span><span id="line-1071"><span class="sd">            - :code:`tree_coords`: :math:`(N, 3)`</span>
+</span><span id="line-1072"><span class="sd">            - :code:`instance_ids`: :math:`(N)`</span>
+</span><span id="line-1073"><span class="sd">            - :code:`grid_origin`: :math:`(2)`</span>
+</span><span id="line-1074"><span class="sd">            - :code:`crown_distance_fields`: :math:`(I&#39;, W, H)`</span>
+</span><span id="line-1075"><span class="sd">            - :code:`seed_mask`: :math:`(N)`</span>
+</span><span id="line-1076"><span class="sd">            - Output: :math:`(N)`.</span>
+</span><span id="line-1077">
+</span><span id="line-1078"><span class="sd">            | where</span>
+</span><span id="line-1079"><span class="sd">            |</span>
+</span><span id="line-1080"><span class="sd">            | :math:`N = \text{ number of tree points}`</span>
+</span><span id="line-1081"><span class="sd">            | :math:`I&#39; = \text{ number of tree instances to segment}`</span>
+</span><span id="line-1082"><span class="sd">            | :math:`W = \text{ extent of the distance fields in x-direction}`</span>
+</span><span id="line-1083"><span class="sd">            | :math:`H = \text{ extent of the distance fields in y-direction}`</span>
+</span><span id="line-1084">
+</span><span id="line-1085"><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="line-1086">        <span class="k">with</span> <span class="n">Timer</span><span class="p">(</span><span class="s2">&quot;Region growing&quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">_time_tracker</span><span class="p">):</span>
+</span><span id="line-1087">            <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Region growing...&quot;</span><span class="p">)</span>
+</span><span id="line-1088">            <span class="k">if</span> <span class="n">seed_mask</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="line-1089">                <span class="k">return</span> <span class="n">instance_ids</span>
+</span><span id="line-1090">
+</span><span id="line-1091">            <span class="n">growing_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_or</span><span class="p">(</span><span class="n">instance_ids</span> <span class="o">==</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="n">seed_mask</span><span class="p">)</span>
+</span><span id="line-1092">            <span class="n">growing_points</span> <span class="o">=</span> <span class="n">tree_coords</span><span class="p">[</span><span class="n">growing_mask</span><span class="p">]</span>
+</span><span id="line-1093">            <span class="n">growing_points</span><span class="p">[:,</span> <span class="mi">2</span><span class="p">]</span> <span class="o">*=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_z_scale</span>
+</span><span id="line-1094">            <span class="n">growing_instance_ids</span> <span class="o">=</span> <span class="n">instance_ids</span><span class="p">[</span><span class="n">growing_mask</span><span class="p">]</span>
+</span><span id="line-1095">            <span class="n">growing_seed_mask</span> <span class="o">=</span> <span class="n">growing_instance_ids</span> <span class="o">!=</span> <span class="o">-</span><span class="mi">1</span>
+</span><span id="line-1096">
+</span><span id="line-1097">            <span class="c1"># the region growing is only executed for certain trees</span>
+</span><span id="line-1098">            <span class="c1"># the following code maps the instance IDs of the trees for which region growing is executed to a</span>
+</span><span id="line-1099">            <span class="c1"># continuous range</span>
+</span><span id="line-1100">            <span class="n">instance_id_mapping</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">full</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">unique_instances_ids</span><span class="p">),</span> <span class="n">fill_value</span><span class="o">=-</span><span class="mi">1</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
+</span><span id="line-1101">            <span class="n">inverse_instance_id_mapping</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">full</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">crown_distance_fields</span><span class="p">),</span> <span class="n">fill_value</span><span class="o">=-</span><span class="mi">1</span><span class="p">,</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
+</span><span id="line-1102">
+</span><span id="line-1103">            <span class="n">region_growing_instance_ids</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">instance_ids</span><span class="p">[</span><span class="n">seed_mask</span><span class="p">])</span>
+</span><span id="line-1104">
+</span><span id="line-1105">            <span class="n">remapped_id</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="line-1106">            <span class="k">for</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">unique_instances_ids</span><span class="p">:</span>
+</span><span id="line-1107">                <span class="k">if</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="n">region_growing_instance_ids</span><span class="p">:</span>
+</span><span id="line-1108">                    <span class="n">instance_id_mapping</span><span class="p">[</span><span class="n">instance_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">remapped_id</span>
+</span><span id="line-1109">                    <span class="n">inverse_instance_id_mapping</span><span class="p">[</span><span class="n">remapped_id</span><span class="p">]</span> <span class="o">=</span> <span class="n">instance_id</span>
+</span><span id="line-1110">                    <span class="n">remapped_id</span> <span class="o">+=</span> <span class="mi">1</span>
+</span><span id="line-1111">
+</span><span id="line-1112">            <span class="n">point_indices</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">arange</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">growing_points</span><span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="n">np</span><span class="o">.</span><span class="n">int64</span><span class="p">)</span>
 </span><span id="line-1113">
-</span><span id="line-1114">            <span class="n">pq</span> <span class="o">=</span> <span class="n">PriorityQueue</span><span class="p">()</span>
-</span><span id="line-1115">            <span class="k">for</span> <span class="n">idx</span><span class="p">,</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">point_indices</span><span class="p">[</span><span class="n">growing_seed_mask</span><span class="p">],</span> <span class="n">growing_instance_ids</span><span class="p">[</span><span class="n">growing_seed_mask</span><span class="p">]):</span>
-</span><span id="line-1116">                <span class="n">pq</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">idx</span><span class="p">,</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">priority</span><span class="o">=-</span><span class="mi">1</span> <span class="o">*</span> <span class="n">np</span><span class="o">.</span><span class="n">inf</span><span class="p">)</span>
-</span><span id="line-1117">
-</span><span id="line-1118">            <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span>
-</span><span id="line-1119">            <span class="k">while</span> <span class="nb">len</span><span class="p">(</span><span class="n">pq</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-</span><span id="line-1120">                <span class="n">seed_index</span><span class="p">:</span> <span class="nb">int</span>
-</span><span id="line-1121">                <span class="n">_</span><span class="p">,</span> <span class="n">seed_index</span><span class="p">,</span> <span class="n">instance_id</span> <span class="o">=</span> <span class="n">pq</span><span class="o">.</span><span class="n">pop</span><span class="p">()</span>  <span class="c1"># type: ignore[assignment]</span>
-</span><span id="line-1122">                <span class="k">if</span> <span class="n">i</span> <span class="o">%</span> <span class="mi">10000</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-</span><span id="line-1123">                    <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Iteration </span><span class="si">%d</span><span class="s2">, seeds to process: </span><span class="si">%d</span><span class="s2">.&quot;</span><span class="p">,</span> <span class="n">i</span><span class="p">,</span> <span class="nb">len</span><span class="p">(</span><span class="n">pq</span><span class="p">))</span>
-</span><span id="line-1124">                <span class="n">growing_instance_ids</span><span class="p">[</span><span class="n">seed_index</span><span class="p">]</span> <span class="o">=</span> <span class="n">instance_id</span>
-</span><span id="line-1125">
-</span><span id="line-1126">                <span class="n">current_neighbor_indices</span> <span class="o">=</span> <span class="n">neighbor_indices</span><span class="p">[</span><span class="n">seed_index</span><span class="p">]</span>
-</span><span id="line-1127">                <span class="n">current_neighbor_dists</span> <span class="o">=</span> <span class="n">neighbor_dists</span><span class="p">[</span><span class="n">seed_index</span><span class="p">]</span>
-</span><span id="line-1128">                <span class="n">current_neighbor_instance_ids</span> <span class="o">=</span> <span class="n">growing_instance_ids</span><span class="p">[</span><span class="n">current_neighbor_indices</span><span class="p">]</span>
-</span><span id="line-1129">
-</span><span id="line-1130">                <span class="n">neighbor_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
-</span><span id="line-1131">                    <span class="n">current_neighbor_instance_ids</span> <span class="o">==</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="n">current_neighbor_dists</span> <span class="o">&lt;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_max_radius_region_growing</span>
-</span><span id="line-1132">                <span class="p">)</span>
-</span><span id="line-1133">                <span class="n">neighbor_indices_to_add</span> <span class="o">=</span> <span class="n">current_neighbor_indices</span><span class="p">[</span><span class="n">neighbor_mask</span><span class="p">]</span>
-</span><span id="line-1134">                <span class="n">neighbor_dists_to_add</span> <span class="o">=</span> <span class="n">current_neighbor_dists</span><span class="p">[</span><span class="n">neighbor_mask</span><span class="p">]</span>
-</span><span id="line-1135">
-</span><span id="line-1136">                <span class="k">for</span> <span class="n">idx</span><span class="p">,</span> <span class="n">dist</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">neighbor_indices_to_add</span><span class="p">,</span> <span class="n">neighbor_dists_to_add</span><span class="p">):</span>
-</span><span id="line-1137">                    <span class="n">grid_index</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">floor</span><span class="p">((</span><span class="n">growing_points</span><span class="p">[</span><span class="n">idx</span><span class="p">,</span> <span class="p">:</span><span class="mi">2</span><span class="p">]</span> <span class="o">-</span> <span class="n">grid_origin</span><span class="p">)</span> <span class="o">/</span> <span class="bp">self</span><span class="o">.</span><span class="n">_grid_size_canopy_height_model</span><span class="p">)</span>
-</span><span id="line-1138">                    <span class="n">grid_index</span> <span class="o">=</span> <span class="n">grid_index</span><span class="o">.</span><span class="n">astype</span><span class="p">(</span><span class="nb">int</span><span class="p">)</span>
-</span><span id="line-1139">                    <span class="n">distance_to_crown_border</span> <span class="o">=</span> <span class="n">crown_distance_fields</span><span class="p">[</span>
-</span><span id="line-1140">                        <span class="n">instance_id_mapping</span><span class="p">[</span><span class="n">instance_id</span><span class="p">],</span> <span class="n">grid_index</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">grid_index</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
-</span><span id="line-1141">                    <span class="p">]</span>
-</span><span id="line-1142">                    <span class="k">if</span> <span class="n">distance_to_crown_border</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
-</span><span id="line-1143">                        <span class="n">dist</span> <span class="o">*=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_multiplier_outside_coarse_border</span>
-</span><span id="line-1144">
-</span><span id="line-1145">                    <span class="n">entry</span> <span class="o">=</span> <span class="n">pq</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">idx</span><span class="p">)</span>
-</span><span id="line-1146">                    <span class="k">if</span> <span class="n">entry</span> <span class="ow">is</span> <span class="kc">None</span> <span class="ow">or</span> <span class="n">entry</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">&gt;</span> <span class="n">dist</span><span class="p">:</span>
-</span><span id="line-1147">                        <span class="n">pq</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">idx</span><span class="p">,</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">priority</span><span class="o">=</span><span class="n">dist</span><span class="p">)</span>
-</span><span id="line-1148">
-</span><span id="line-1149">                <span class="n">i</span> <span class="o">+=</span> <span class="mi">1</span>
-</span><span id="line-1150">
-</span><span id="line-1151">            <span class="n">instance_ids</span><span class="p">[</span><span class="n">growing_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">growing_instance_ids</span>
-</span><span id="line-1152">
-</span><span id="line-1153">            <span class="k">return</span> <span class="n">instance_ids</span></div>
+</span><span id="line-1114">            <span class="n">kd_tree</span> <span class="o">=</span> <span class="n">KDTree</span><span class="p">(</span><span class="n">growing_points</span><span class="p">)</span>
+</span><span id="line-1115">            <span class="n">neighbor_dists</span><span class="p">,</span> <span class="n">neighbor_indices</span><span class="p">,</span> <span class="n">_</span> <span class="o">=</span> <span class="n">kd_tree</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">growing_points</span><span class="p">,</span> <span class="n">k</span><span class="o">=</span><span class="bp">self</span><span class="o">.</span><span class="n">_num_neighbors_region_growing</span><span class="p">)</span>
+</span><span id="line-1116">
+</span><span id="line-1117">            <span class="n">pq</span> <span class="o">=</span> <span class="n">PriorityQueue</span><span class="p">()</span>
+</span><span id="line-1118">            <span class="k">for</span> <span class="n">idx</span><span class="p">,</span> <span class="n">instance_id</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">point_indices</span><span class="p">[</span><span class="n">growing_seed_mask</span><span class="p">],</span> <span class="n">growing_instance_ids</span><span class="p">[</span><span class="n">growing_seed_mask</span><span class="p">]):</span>
+</span><span id="line-1119">                <span class="n">pq</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">idx</span><span class="p">,</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">priority</span><span class="o">=-</span><span class="mi">1</span> <span class="o">*</span> <span class="n">np</span><span class="o">.</span><span class="n">inf</span><span class="p">)</span>
+</span><span id="line-1120">
+</span><span id="line-1121">            <span class="n">i</span> <span class="o">=</span> <span class="mi">0</span>
+</span><span id="line-1122">            <span class="k">while</span> <span class="nb">len</span><span class="p">(</span><span class="n">pq</span><span class="p">)</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="line-1123">                <span class="n">seed_index</span><span class="p">:</span> <span class="nb">int</span>
+</span><span id="line-1124">                <span class="n">_</span><span class="p">,</span> <span class="n">seed_index</span><span class="p">,</span> <span class="n">instance_id</span> <span class="o">=</span> <span class="n">pq</span><span class="o">.</span><span class="n">pop</span><span class="p">()</span>  <span class="c1"># type: ignore[assignment]</span>
+</span><span id="line-1125">                <span class="k">if</span> <span class="n">i</span> <span class="o">%</span> <span class="mi">10000</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="line-1126">                    <span class="bp">self</span><span class="o">.</span><span class="n">_logger</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Iteration </span><span class="si">%d</span><span class="s2">, seeds to process: </span><span class="si">%d</span><span class="s2">.&quot;</span><span class="p">,</span> <span class="n">i</span><span class="p">,</span> <span class="nb">len</span><span class="p">(</span><span class="n">pq</span><span class="p">))</span>
+</span><span id="line-1127">                <span class="n">growing_instance_ids</span><span class="p">[</span><span class="n">seed_index</span><span class="p">]</span> <span class="o">=</span> <span class="n">instance_id</span>
+</span><span id="line-1128">
+</span><span id="line-1129">                <span class="n">current_neighbor_indices</span> <span class="o">=</span> <span class="n">neighbor_indices</span><span class="p">[</span><span class="n">seed_index</span><span class="p">]</span>
+</span><span id="line-1130">                <span class="n">current_neighbor_dists</span> <span class="o">=</span> <span class="n">neighbor_dists</span><span class="p">[</span><span class="n">seed_index</span><span class="p">]</span>
+</span><span id="line-1131">                <span class="n">current_neighbor_instance_ids</span> <span class="o">=</span> <span class="n">growing_instance_ids</span><span class="p">[</span><span class="n">current_neighbor_indices</span><span class="p">]</span>
+</span><span id="line-1132">
+</span><span id="line-1133">                <span class="n">neighbor_mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">logical_and</span><span class="p">(</span>
+</span><span id="line-1134">                    <span class="n">current_neighbor_instance_ids</span> <span class="o">==</span> <span class="o">-</span><span class="mi">1</span><span class="p">,</span> <span class="n">current_neighbor_dists</span> <span class="o">&lt;=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_max_radius_region_growing</span>
+</span><span id="line-1135">                <span class="p">)</span>
+</span><span id="line-1136">                <span class="n">neighbor_indices_to_add</span> <span class="o">=</span> <span class="n">current_neighbor_indices</span><span class="p">[</span><span class="n">neighbor_mask</span><span class="p">]</span>
+</span><span id="line-1137">                <span class="n">neighbor_dists_to_add</span> <span class="o">=</span> <span class="n">current_neighbor_dists</span><span class="p">[</span><span class="n">neighbor_mask</span><span class="p">]</span>
+</span><span id="line-1138">
+</span><span id="line-1139">                <span class="k">for</span> <span class="n">idx</span><span class="p">,</span> <span class="n">dist</span> <span class="ow">in</span> <span class="nb">zip</span><span class="p">(</span><span class="n">neighbor_indices_to_add</span><span class="p">,</span> <span class="n">neighbor_dists_to_add</span><span class="p">):</span>
+</span><span id="line-1140">                    <span class="n">grid_index</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">floor</span><span class="p">((</span><span class="n">growing_points</span><span class="p">[</span><span class="n">idx</span><span class="p">,</span> <span class="p">:</span><span class="mi">2</span><span class="p">]</span> <span class="o">-</span> <span class="n">grid_origin</span><span class="p">)</span> <span class="o">/</span> <span class="bp">self</span><span class="o">.</span><span class="n">_grid_size_canopy_height_model</span><span class="p">)</span>
+</span><span id="line-1141">                    <span class="n">grid_index</span> <span class="o">=</span> <span class="n">grid_index</span><span class="o">.</span><span class="n">astype</span><span class="p">(</span><span class="nb">int</span><span class="p">)</span>
+</span><span id="line-1142">                    <span class="n">distance_to_crown_border</span> <span class="o">=</span> <span class="n">crown_distance_fields</span><span class="p">[</span>
+</span><span id="line-1143">                        <span class="n">instance_id_mapping</span><span class="p">[</span><span class="n">instance_id</span><span class="p">],</span> <span class="n">grid_index</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">grid_index</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
+</span><span id="line-1144">                    <span class="p">]</span>
+</span><span id="line-1145">                    <span class="k">if</span> <span class="n">distance_to_crown_border</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">:</span>
+</span><span id="line-1146">                        <span class="n">dist</span> <span class="o">*=</span> <span class="bp">self</span><span class="o">.</span><span class="n">_multiplier_outside_coarse_border</span>
+</span><span id="line-1147">
+</span><span id="line-1148">                    <span class="n">entry</span> <span class="o">=</span> <span class="n">pq</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">idx</span><span class="p">)</span>
+</span><span id="line-1149">                    <span class="k">if</span> <span class="n">entry</span> <span class="ow">is</span> <span class="kc">None</span> <span class="ow">or</span> <span class="n">entry</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="o">&gt;</span> <span class="n">dist</span><span class="p">:</span>
+</span><span id="line-1150">                        <span class="n">pq</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">idx</span><span class="p">,</span> <span class="n">instance_id</span><span class="p">,</span> <span class="n">priority</span><span class="o">=</span><span class="n">dist</span><span class="p">)</span>
+</span><span id="line-1151">
+</span><span id="line-1152">                <span class="n">i</span> <span class="o">+=</span> <span class="mi">1</span>
+</span><span id="line-1153">
+</span><span id="line-1154">            <span class="n">instance_ids</span><span class="p">[</span><span class="n">growing_mask</span><span class="p">]</span> <span class="o">=</span> <span class="n">growing_instance_ids</span>
+</span><span id="line-1155">
+</span><span id="line-1156">            <span class="k">return</span> <span class="n">instance_ids</span></div>
 </div>
 
 </span></code></pre></div>

--- a/src/pointtree/instance_segmentation/_multi_stage_algorithm.py
+++ b/src/pointtree/instance_segmentation/_multi_stage_algorithm.py
@@ -680,10 +680,13 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
                         tree_positions=tree_positions_grid,
                     )
 
-            mask = instance_ids == -1
-            grid_indices = np.floor(
-                (tree_coords[mask][:, :2] - grid_origin) / self._grid_size_canopy_height_model
-            ).astype(int)
+            grid_indices = np.floor((tree_coords[:, :2] - grid_origin) / self._grid_size_canopy_height_model).astype(
+                int
+            )
+            mask = np.logical_and(
+                instance_ids == -1, (grid_indices < watershed_labels_without_border.shape).all(axis=1)
+            )
+            grid_indices = grid_indices[mask]
             instance_ids[mask] = watershed_labels_without_border[grid_indices[:, 0], grid_indices[:, 1]] - 1
             instance_ids, unique_instance_ids = remap_instance_ids(instance_ids)
 


### PR DESCRIPTION
This pull request fixes the following bug: The canopy height model may be computed using the tree crown points only. In that case, some tree trunk points can be located outside the boundaries of the canopy height model. Therefore, a check is added to ensure that the canopy height model is only accessed with valid indices.