### PR TITLE
docs: fix workflow for removing docs deployment after a PR is closed

### DIFF
--- a/.github/workflows/clean-up-pull-requests.yml
+++ b/.github/workflows/clean-up-pull-requests.yml
@@ -7,13 +7,12 @@ on:
     types: [closed]
 
 jobs:
-  validate-pr-title:
+  clean-up-pr:
     runs-on: ubuntu-latest
     steps:
       - name: Remove documentation deployment
         shell: bash
         run: |
-          cd /github/workspace/docs
           rclone config create --non-interactive docs-cloud webdav url=${{ secrets.DOCS_CLOUD_URL }} \
             pass=${{ secrets.DOCS_CLOUD_PASSWORD }} vendor=${{ secrets.DOCS_CLOUD_VENDOR }} \
             user=${{ secrets.DOCS_CLOUD_USER }}

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
-        <text x="80" y="14">77%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">84%</text>
+        <text x="80" y="14">84%</text>
     </g>
 </svg>


### PR DESCRIPTION
This pull request fixes the Github workflow that removes the documentation deployment of a pull request after the pull request is merged or closed.