### PR TITLE
docs: fix workflow for removing docs deployment after a PR is closed

### DIFF
--- a/.github/workflows/clean-up-pull-requests.yml
+++ b/.github/workflows/clean-up-pull-requests.yml
@@ -23,11 +23,4 @@ jobs:
           rclone config create --non-interactive docs-cloud webdav url=${{ secrets.DOCS_CLOUD_URL }} \
             pass=${{ secrets.DOCS_CLOUD_PASSWORD }} vendor=${{ secrets.DOCS_CLOUD_VENDOR }} \
             user=${{ secrets.DOCS_CLOUD_USER }}
-          rclone copy docs-cloud:pointtree-docs/ all_builds
-          cd all_builds
-          ls
-          cd ..
-          echo ${{ github.event.number }}
-          echo "all_builds/pr${{ github.event.number }}"
-          rm -rf "all_builds/pr${{ github.event.number }}"
-          rclone sync all_builds docs-cloud:pointtree-docs
+          rclone purge docs-cloud:pointtree-docs/pr${{ github.event.number }}

--- a/.github/workflows/clean-up-pull-requests.yml
+++ b/.github/workflows/clean-up-pull-requests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [closed]
 
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   clean-up-pr:
     runs-on: ubuntu-latest
@@ -21,5 +24,10 @@ jobs:
             pass=${{ secrets.DOCS_CLOUD_PASSWORD }} vendor=${{ secrets.DOCS_CLOUD_VENDOR }} \
             user=${{ secrets.DOCS_CLOUD_USER }}
           rclone copy docs-cloud:pointtree-docs/ all_builds
+          cd all_builds
+          ls
+          cd ..
+          echo ${{ github.event.number }}
+          echo "all_builds/pr${{ github.event.number }}"
           rm -rf "all_builds/pr${{ github.event.number }}"
           rclone sync all_builds docs-cloud:pointtree-docs

--- a/.github/workflows/clean-up-pull-requests.yml
+++ b/.github/workflows/clean-up-pull-requests.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     types: [closed]
 
-  # Allows to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 jobs:
   clean-up-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request fixes the Github workflow that removes the documentation deployment of a pull request after the pull request is merged or closed.