### PR TITLE
ci: remove unused .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-omit =
-    # excludes tests from coverage measurements
-    test/*


### PR DESCRIPTION
Remove .coveragerc file as the `coverage` package was replaced by the `pytets-cov` package in #39.