### PR TITLE
ci: re-add .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    # excludes tests from coverage measurements
+    test/*


### PR DESCRIPTION
This pull request re-adds the .coveragerc file that was removed in #45 since this file is still needed by pytest-cov.