### PR TITLE
ci: set concurrency for PR clean-up workflow

### DIFF
--- a/.github/workflows/clean-up-pull-requests.yml
+++ b/.github/workflows/clean-up-pull-requests.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     types: [closed]
 
+# Allow only one concurrent run, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these runs to complete.
+# Unfortunately, there is no option to disable skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: clean-up-pr
+  cancel-in-progress: false
+
 jobs:
   clean-up-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sets the concurrency for the PR clean-up workflow. Unfortunately, Github does not provide an option to disable skipping runs queued between the run in-progress and the latest queued (see [#41518](https://github.com/orgs/community/discussions/41518)). If several pull requests are merged shortly after each other, this can result in no clean-up being carried out for some of them.