### PR TITLE
ci: remove parameterized from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dev = [
     "black",
     "mypy",
     "pandas-stubs",
-    "parameterized",
     "pylint",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This pull request removes the parameterized package from the package dependencies since it is not used anymore.