### PR TITLE
ci: fix PR clean-up workflow

### DIFF
--- a/.github/workflows/clean-up-pull-requests.yml
+++ b/.github/workflows/clean-up-pull-requests.yml
@@ -17,10 +17,8 @@ jobs:
   clean-up-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Install rclone
-        shell: bash
-        run: |
-          curl https://rclone.org/install.sh | bash
+      - name: Setup Rclone
+        uses: AnimMouse/setup-rclone@v1
       - name: Remove documentation deployment
         shell: bash
         run: |


### PR DESCRIPTION
This pull request fixes the rclone setup in the PR clean-up CI workflow, which was broken by #62.