### PR TITLE
ci: install SSH client in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime
 COPY --from=builder /opt/conda/lib/python3.11/site-packages/pytorch3d /opt/conda/lib/python3.11/site-packages
 COPY --from=builder /opt/conda/lib/python3.11/site-packages/pytorch3d-*.dist-info /opt/conda/lib/python3.11/site-packages
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl git gnupg make unzip && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl git gnupg make openssh-client unzip && \
     curl https://rclone.org/install.sh | bash
 
 RUN python -m pip install \


### PR DESCRIPTION
This pull request adds an SSH client to the pointtree Docker image since this is needed for the release workflow implemented in #65.