### PR TITLE
docs: document setup of pre-commit hooks

### DIFF
--- a/docs/source/develop/index.rst
+++ b/docs/source/develop/index.rst
@@ -4,6 +4,16 @@
    :description: Information on how to contribute to the package development.
    :twitter:description: Information on how to contribute to the package development.
 
+Pre-Commit Hooks
+------------------
+
+To set up pre-commit hooks that automatically check your code when you commit, run the following in the root directory
+of the repository
+
+.. code-block:: bash
+
+   $ pre-commit install
+
 Testing
 ------------------
 


### PR DESCRIPTION
This pull request adds a section to the documentation that documents how to setup the pre-commit hooks of the repository.