### PR TITLE
feat: add operations to filter instances

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "black",
     "mypy",
     "pandas-stubs",
+    "pre-commit",
     "pylint",
     "pytest",
     "pytest-cov",

--- a/src/pointtree/instance_segmentation/_multi_stage_algorithm.py
+++ b/src/pointtree/instance_segmentation/_multi_stage_algorithm.py
@@ -450,9 +450,9 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
         height_map = np.zeros(num_cells)
         height_map[unique_grid_indices_np[:, 0], unique_grid_indices_np[:, 1]] = max_height.cpu().numpy()
         point_counts = np.zeros(num_cells)
-        point_counts[
-            unique_grid_indices_np[:, 0], unique_grid_indices_np[:, 1]
-        ] = point_counts_per_grid_cell.cpu().numpy()
+        point_counts[unique_grid_indices_np[:, 0], unique_grid_indices_np[:, 1]] = (
+            point_counts_per_grid_cell.cpu().numpy()
+        )
 
         return height_map, point_counts, first_cell * grid_size
 
@@ -883,14 +883,14 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
                     for instance_id in neighbor_instance_ids:
                         tree_position = tree_positions_grid[instance_id - 1]
                         voronoi_id = voronoi_labels_without_border[tree_position[0], tree_position[1]]
-                        voronoi_labels_without_border_remapped[
-                            voronoi_labels_without_border == voronoi_id
-                        ] = instance_id
+                        voronoi_labels_without_border_remapped[voronoi_labels_without_border == voronoi_id] = (
+                            instance_id
+                        )
                         voronoi_labels_with_border_remapped[voronoi_labels_with_border == voronoi_id] = instance_id
 
-                    watershed_labels_without_border[
-                        neighborhood_mask_without_border
-                    ] = voronoi_labels_without_border_remapped[neighborhood_mask_without_border]
+                    watershed_labels_without_border[neighborhood_mask_without_border] = (
+                        voronoi_labels_without_border_remapped[neighborhood_mask_without_border]
+                    )
 
                     # find outer boundaries to other trees that were not included in the Voronoi segmentation
                     outer_boundaries = find_boundaries(neighborhood_mask_without_border, mode="inner", background=0)

--- a/src/pointtree/instance_segmentation/_multi_stage_algorithm.py
+++ b/src/pointtree/instance_segmentation/_multi_stage_algorithm.py
@@ -18,6 +18,7 @@ from torch_scatter import scatter_max
 from pointtree.evaluation import Timer
 from pointtree.operations import make_labels_consecutive
 from pointtree.visualization import save_tree_map
+from .filters import filter_instances_min_points
 from ._priority_queue import PriorityQueue
 from ._instance_segmentation_algorithm import InstanceSegmentationAlgorithm
 
@@ -217,9 +218,11 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
             return instance_ids, unique_instance_ids
 
         instance_ids, unique_instance_ids = self.cluster_trunks(tree_coords, classification)
-        instance_ids, unique_instance_ids = self.filter_trunk_clusters(
-            instance_ids, unique_instance_ids, self._min_trunk_points
-        )
+        with Timer("Filtering of trunk clusters", self._time_tracker):
+            self._logger.info("Filter trunk clusters...")
+            instance_ids, unique_instance_ids = filter_instances_min_points(
+                instance_ids, unique_instance_ids, self._min_trunk_points
+            )
         trunk_positions = self.compute_trunk_positions(tree_coords, instance_ids, unique_instance_ids)
 
         tree_positions = self.match_trunk_and_crown_tops(
@@ -330,45 +333,6 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
             return make_labels_consecutive(  # type: ignore[return-value]
                 instance_ids, ignore_id=-1, inplace=True, return_unique_labels=True
             )
-
-    def filter_trunk_clusters(
-        self, instance_ids: np.ndarray, unique_instance_ids: np.ndarray, min_points: int
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        r"""
-        Removes trunk instances with less than :code:`min_points` from the set of trunk instances.
-
-        Args:
-            instance_ids: Instance IDs of each tree point.
-            unique_instance_ids: Unique instance IDs.
-            min_points: Minimum number of points an instance must have to not be discarded.
-
-        Returns:
-            Tuple of two arrays. The first contains the updated instance ID of each tree point. Points that do not
-            belong to any instance are assigned the ID :math:`-1`. The second contains the unique instance IDs.
-
-        Shape:
-            - :code:`instance_ids`: :math:`(N)`
-            - :code:`unique_instance_ids`: :math:`(T)`
-            - Output: Tuple of two arrays. The first has shape :math:`(N)` and the second :math:`(T')`
-
-            | where
-            |
-            | :math:`N = \text{ number of tree points}`
-            | :math:`T = \text{ number of trunk instances}`
-            | :math:`T' = \text{ number of trunk instances after filtering}`
-        """
-
-        with Timer("Filtering of trunk clusters", self._time_tracker):
-            self._logger.info("Filter trunk clusters...")
-            for instance_id in unique_instance_ids:
-                instance_mask = instance_ids == instance_id
-                instance_points = instance_mask.sum()
-                if instance_points < min_points:
-                    instance_ids[instance_mask] = -1
-                    self._logger.info("Discard trunk cluster %d", instance_id)
-        return make_labels_consecutive(  # type: ignore[return-value]
-            instance_ids, ignore_id=-1, inplace=True, return_unique_labels=True
-        )
 
     def compute_trunk_positions(
         self, tree_coords: np.ndarray, instance_ids: np.ndarray, unique_instance_ids: np.ndarray
@@ -486,9 +450,9 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
         height_map = np.zeros(num_cells)
         height_map[unique_grid_indices_np[:, 0], unique_grid_indices_np[:, 1]] = max_height.cpu().numpy()
         point_counts = np.zeros(num_cells)
-        point_counts[unique_grid_indices_np[:, 0], unique_grid_indices_np[:, 1]] = (
-            point_counts_per_grid_cell.cpu().numpy()
-        )
+        point_counts[
+            unique_grid_indices_np[:, 0], unique_grid_indices_np[:, 1]
+        ] = point_counts_per_grid_cell.cpu().numpy()
 
         return height_map, point_counts, first_cell * grid_size
 
@@ -919,14 +883,14 @@ class MultiStageAlgorithm(InstanceSegmentationAlgorithm):  # pylint: disable=too
                     for instance_id in neighbor_instance_ids:
                         tree_position = tree_positions_grid[instance_id - 1]
                         voronoi_id = voronoi_labels_without_border[tree_position[0], tree_position[1]]
-                        voronoi_labels_without_border_remapped[voronoi_labels_without_border == voronoi_id] = (
-                            instance_id
-                        )
+                        voronoi_labels_without_border_remapped[
+                            voronoi_labels_without_border == voronoi_id
+                        ] = instance_id
                         voronoi_labels_with_border_remapped[voronoi_labels_with_border == voronoi_id] = instance_id
 
-                    watershed_labels_without_border[neighborhood_mask_without_border] = (
-                        voronoi_labels_without_border_remapped[neighborhood_mask_without_border]
-                    )
+                    watershed_labels_without_border[
+                        neighborhood_mask_without_border
+                    ] = voronoi_labels_without_border_remapped[neighborhood_mask_without_border]
 
                     # find outer boundaries to other trees that were not included in the Voronoi segmentation
                     outer_boundaries = find_boundaries(neighborhood_mask_without_border, mode="inner", background=0)

--- a/src/pointtree/instance_segmentation/filters.py
+++ b/src/pointtree/instance_segmentation/filters.py
@@ -1,0 +1,111 @@
+""" Methods to filter instances. """
+
+__all__ = ["filter_instances_min_points", "filter_instances_vertical_extent"]
+
+from typing import Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from pointtree.operations import make_labels_consecutive
+
+
+def filter_instances_min_points(
+    instance_ids: npt.NDArray[np.int64],
+    unique_instance_ids: npt.NDArray[np.int64],
+    min_points: Optional[int],
+    inplace: bool = False,
+) -> Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    r"""
+    Removes instances with less than :code:`min_points`.
+
+    Args:
+        instance_ids: Instance IDs of the points.
+        unique_instance_ids: Unique instance IDs.
+        min_points: Minimum number of points an instance must have to not be discarded. If set to :code:`None`, the
+            instances are not filtered.
+        inplace: Whether the filtering should be applied inplace to the :code:`instance_ids` array. Defaults to
+            :code:`False`.
+
+    Returns:
+        Tuple of two arrays. The first contains the updated instance ID of each point. Points that do not
+        belong to any instance are assigned the ID :math:`-1`. The second contains the unique instance IDs.
+
+    Shape:
+        - :code:`instance_ids`: :math:`(N)`
+        - :code:`unique_instance_ids`: :math:`(I)`
+        - Output: Tuple of two arrays. The first has shape :math:`(N)` and the second :math:`(I')`
+
+        | where
+        |
+        | :math:`N = \text{ number of points}`
+        | :math:`I = \text{ number of instances before filtering}`
+        | :math:`I' = \text{ number of instances after filtering}`
+    """
+
+    if min_points is None:
+        return instance_ids, unique_instance_ids
+
+    unique_instance_ids, point_counts = np.unique(instance_ids, return_counts=True)
+    discarded_instance_ids = unique_instance_ids[point_counts < min_points]
+    instance_ids[np.in1d(instance_ids, discarded_instance_ids)] = -1
+
+    return make_labels_consecutive(  # type: ignore[return-value]
+        instance_ids, ignore_id=-1, inplace=inplace, return_unique_labels=True
+    )
+
+
+def filter_instances_vertical_extent(
+    coords: npt.NDArray[np.float64],
+    instance_ids: npt.NDArray[np.int64],
+    unique_instance_ids: npt.NDArray[np.int64],
+    min_vertical_extent: Optional[int],
+    inplace: bool = False,
+) -> Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    r"""
+    Removes instances whose extent in z-direction is less than :code:`min_vertical_extent`.
+
+    Args:
+        instance_ids: Instance IDs of the points.
+        unique_instance_ids: Unique instance IDs.
+        min_vertical_extent: Minimum vertical extent an instance must have to not be discarded. If set to :code:`None`,
+            the instances are not filtered.
+        inplace: Whether the filtering should be applied inplace to the :code:`instance_ids` array. Defaults to
+            :code:`False`.
+
+    Returns:
+        Tuple of two arrays. The first contains the updated instance ID of each point. Points that do not
+        belong to any instance are assigned the ID :math:`-1`. The second contains the unique instance IDs.
+
+    Shape:
+        - :code:`instance_ids`: :math:`(N)`
+        - :code:`unique_instance_ids`: :math:`(I)`
+        - Output: Tuple of two arrays. The first has shape :math:`(N)` and the second :math:`(I')`
+
+        | where
+        |
+        | :math:`N = \text{ number of points}`
+        | :math:`I = \text{ number of instances before filtering}`
+        | :math:`I' = \text{ number of instances after filtering}`
+    """
+
+    if len(instance_ids) != len(coords):
+        raise ValueError("coords and instance_ids must have the same length.")
+
+    if min_vertical_extent is None:
+        return instance_ids, unique_instance_ids
+
+    unique_instance_ids, inverse_indices = np.unique(instance_ids, return_inverse=True)
+
+    min_z_per_cluster = np.full(len(unique_instance_ids), fill_value=np.inf, dtype=coords.dtype)
+    max_z_per_cluster = np.full(len(unique_instance_ids), fill_value=-np.inf, dtype=coords.dtype)
+
+    np.minimum.at(min_z_per_cluster, inverse_indices, coords[:, 2])
+    np.maximum.at(max_z_per_cluster, inverse_indices, coords[:, 2])
+
+    discarded_instance_ids = unique_instance_ids[max_z_per_cluster - min_z_per_cluster < min_vertical_extent]
+    instance_ids[np.in1d(instance_ids, discarded_instance_ids)] = -1
+
+    return make_labels_consecutive(  # type: ignore[return-value]
+        instance_ids, ignore_id=-1, inplace=inplace, return_unique_labels=True
+    )

--- a/test/instance_segmentation/test_filters.py
+++ b/test/instance_segmentation/test_filters.py
@@ -1,0 +1,57 @@
+""" Tests for :code:`pointtree.instance_segmentation.filters`. """
+
+import numpy as np
+
+from pointtree.instance_segmentation.filters import filter_instances_min_points, filter_instances_vertical_extent
+
+
+class TestFilterInstances:
+    """Tests for :code:`pointtree.instance_segmentation.filters`."""
+
+    def test_filter_instances_min_points(self):
+        instance_ids = np.array([0] * 3 + [-1] * 7 + [1] * 10, dtype=np.int64)
+        unique_instance_ids = np.array([0, 1], dtype=np.int64)
+        expected_filtered_instance_ids = np.array([-1] * 10 + [0] * 10, dtype=np.int64)
+
+        filtered_instance_ids, filtered_unique_instance_ids = filter_instances_min_points(
+            instance_ids, unique_instance_ids, min_points=5
+        )
+
+        np.testing.assert_array_equal(expected_filtered_instance_ids, filtered_instance_ids)
+        np.testing.assert_array_equal(np.array([0], dtype=np.int64), filtered_unique_instance_ids)
+
+    def test_filter_instances_min_points_none(self):
+        instance_ids = np.arange(10, dtype=np.int64)
+        unique_instance_ids = instance_ids
+
+        filtered_instance_ids, filtered_unique_instance_ids = filter_instances_min_points(
+            instance_ids, unique_instance_ids, min_points=None
+        )
+
+        np.testing.assert_array_equal(instance_ids, filtered_instance_ids)
+        np.testing.assert_array_equal(unique_instance_ids, filtered_unique_instance_ids)
+
+    def test_filter_instances_vertical_extent(self):
+        coords = np.array([[0, 0, 0], [0, 0, 1], [0, 0, 0], [1, 0, 1], [1, 1, 10]], dtype=np.float64)
+        instance_ids = np.array([0] * 2 + [-1] + [1] * 2, dtype=np.int64)
+        unique_instance_ids = np.array([0, 1], dtype=np.int64)
+        expected_filtered_instance_ids = np.array([-1] * 3 + [0] * 2, dtype=np.int64)
+
+        filtered_instance_ids, filtered_unique_instance_ids = filter_instances_vertical_extent(
+            coords, instance_ids, unique_instance_ids, min_vertical_extent=3
+        )
+
+        np.testing.assert_array_equal(expected_filtered_instance_ids, filtered_instance_ids)
+        np.testing.assert_array_equal(np.array([0], dtype=np.int64), filtered_unique_instance_ids)
+
+    def test_filter_instances_vertical_extent_none(self):
+        coords = np.zeros((10, 3), dtype=np.float64)
+        instance_ids = np.array([0] * 5 + [1] * 5, dtype=np.int64)
+        unique_instance_ids = instance_ids
+
+        filtered_instance_ids, filtered_unique_instance_ids = filter_instances_vertical_extent(
+            coords, instance_ids, unique_instance_ids, min_vertical_extent=None
+        )
+
+        np.testing.assert_array_equal(instance_ids, filtered_instance_ids)
+        np.testing.assert_array_equal(unique_instance_ids, filtered_unique_instance_ids)

--- a/test/instance_segmentation/test_multi_stage_algorithm.py
+++ b/test/instance_segmentation/test_multi_stage_algorithm.py
@@ -66,20 +66,6 @@ class TestMultiStageAlgorithm:  # pylint: disable=too-many-public-methods
         np.testing.assert_array_equal(expected_instance_ids, instance_ids)
         np.testing.assert_array_equal(expected_unique_ids, unique_instance_ids)
 
-    def test_filter_trunk_clusters(self):
-        instance_ids = np.array([0] * 3 + [-1] * 7 + [1] * 10, dtype=np.int64)
-        unique_instance_ids = np.array([0, 1], dtype=np.int64)
-        expected_filtered_instance_ids = np.array([-1] * 10 + [0] * 10, dtype=np.int64)
-
-        algorithm = MultiStageAlgorithm(trunk_class_id=0, crown_class_id=1)
-
-        instance_ids, unique_instance_ids = algorithm.filter_trunk_clusters(
-            instance_ids, unique_instance_ids, min_points=5
-        )
-
-        np.testing.assert_array_equal(expected_filtered_instance_ids, instance_ids)
-        np.testing.assert_array_equal(np.array([0], dtype=np.int64), unique_instance_ids)
-
     def test_compute_trunk_positions(self):
         tree_coords = np.array([[0, 0, 0], [1, 2, 3], [4, 4, 4], [5, 6, 6]], dtype=float)
         instance_ids = np.array([0, 0, -1, 1], dtype=np.int64)
@@ -139,9 +125,12 @@ class TestMultiStageAlgorithm:  # pylint: disable=too-many-public-methods
 
         algorithm = MultiStageAlgorithm(trunk_class_id=0, crown_class_id=1)
 
-        crown_top_positions, crown_top_positions_grid, canopy_height_model, grid_origin = (
-            algorithm.compute_crown_top_positions(tree_coords, classification)
-        )
+        (
+            crown_top_positions,
+            crown_top_positions_grid,
+            canopy_height_model,
+            grid_origin,
+        ) = algorithm.compute_crown_top_positions(tree_coords, classification)
 
         assert len(crown_top_positions) == 0
         assert len(crown_top_positions_grid) == 0
@@ -202,26 +191,26 @@ class TestMultiStageAlgorithm:  # pylint: disable=too-many-public-methods
 
         if min_points_crown_detection <= 1:
             if min_distance_crown_tops <= 2:
-                expected_crown_top_positions_grid = [[1, 1], [3, 1], [5, 4]]
-                tree_heights = [2, 3, 4]
+                expected_crown_top_positions_grid_list = [[1, 1], [3, 1], [5, 4]]
+                tree_heights_list = [2, 3, 4]
             elif min_distance_crown_tops <= np.linalg.norm([2, 3]):
-                expected_crown_top_positions_grid = [[3, 1], [5, 4]]
-                tree_heights = [3, 4]
+                expected_crown_top_positions_grid_list = [[3, 1], [5, 4]]
+                tree_heights_list = [3, 4]
             else:
-                expected_crown_top_positions_grid = [[5, 4]]
-                tree_heights = [4]
+                expected_crown_top_positions_grid_list = [[5, 4]]
+                tree_heights_list = [4]
         else:
-            expected_crown_top_positions_grid = [[3, 1]]
-            tree_heights = [3]
+            expected_crown_top_positions_grid_list = [[3, 1]]
+            tree_heights_list = [3]
 
         if algorithm == "watershed_crown_top_positions":
             expected_canopy_height_model[5, 0] = 1
             if min_tree_height <= 1 and min_distance_crown_tops <= np.linalg.norm([1, 2]):
-                expected_crown_top_positions_grid.append([5, 0])
-                tree_heights.append(1)
+                expected_crown_top_positions_grid_list.append([5, 0])
+                tree_heights_list.append(1)
 
-        tree_heights = np.array(tree_heights, dtype=float)
-        expected_crown_top_positions_grid = np.array(expected_crown_top_positions_grid, dtype=np.int64)
+        tree_heights = np.array(tree_heights_list, dtype=float)
+        expected_crown_top_positions_grid = np.array(expected_crown_top_positions_grid_list, dtype=np.int64)
         expected_crown_top_positions_grid = expected_crown_top_positions_grid[tree_heights > min_tree_height]
         expected_crown_top_positions = expected_crown_top_positions_grid.astype(np.float64) + expected_grid_origin
 
@@ -236,9 +225,12 @@ class TestMultiStageAlgorithm:  # pylint: disable=too-many-public-methods
             smooth_canopy_height_model=False,
         )
 
-        crown_top_positions, crown_top_positions_grid, canopy_height_model, grid_origin = (
-            algorithm.compute_crown_top_positions(tree_coords, classification)
-        )
+        (
+            crown_top_positions,
+            crown_top_positions_grid,
+            canopy_height_model,
+            grid_origin,
+        ) = algorithm.compute_crown_top_positions(tree_coords, classification)
 
         np.testing.assert_array_equal(
             np.unique(expected_crown_top_positions, axis=0), np.unique(crown_top_positions, axis=0)


### PR DESCRIPTION
This pull request adds the module `pointtree.instance_segmentation.filters` that provides the following methods to filter instances:

- `filter_instances_min_points`: Removes instances with too few points.
- `filter_instances_vertical_extent`: Removes instances whose extent in z-direction is too small.

BREAKING CHANGE: the `filter_trunk_clusters` method is removed from the `MultiStageAlgorithm` class and replaced by the new filter methods.