### PR TITLE
feat: operation to compute polygon area

### DIFF
--- a/src/pointtree/operations/__init__.py
+++ b/src/pointtree/operations/__init__.py
@@ -4,5 +4,6 @@ from ._cloth_simulation_filtering import *
 from ._create_digital_terrain_model import *
 from ._normalize_height import *
 from ._points_in_ellipse import *
+from ._polygon_area import *
 
 __all__ = [name for name in globals().keys() if not name.startswith("_")]

--- a/src/pointtree/operations/_polygon_area.py
+++ b/src/pointtree/operations/_polygon_area.py
@@ -1,0 +1,31 @@
+""" Computation of a polygon's area. """
+
+__all__ = ["polygon_area"]
+
+import numpy as np
+import numpy.typing as npt
+
+
+def polygon_area(x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]) -> float:
+    r"""
+    Computes the area of a convex polygon using the
+    `Shoelace formula <https://en.wikipedia.org/wiki/Shoelace_formula>`__. It is expected that the input vertices are
+    already sorted so that adjacent vertices are neighbors in the input vertex array.
+
+    Args:
+        x: X-coordinates of the polygon vertices.
+        y: Y-coordinates of the polygon vertices.
+
+    Returns:
+        Polygon area.
+
+    Shape:
+        - :code:`x`: :math:`(N)`
+        - :code:`y`: :math:`(N)`
+
+        | where
+        |
+        | :math:`n = \text{ number of points}`
+    """
+
+    return 0.5 * np.abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))

--- a/test/operations/test_polygon_area.py
+++ b/test/operations/test_polygon_area.py
@@ -1,0 +1,39 @@
+""" Tests for pointtree.operations.polygon_area. """
+
+import numpy as np
+
+from pointtree.operations import polygon_area
+
+
+class TestPolygonArea:
+    """Tests for pointtree.operations.polygon_area."""
+
+    def test_triangle(self):
+        x = np.array([-1, -1, 1], dtype=np.float64)
+        y = np.array([-1, 1, 1], dtype=np.float64)
+
+        expected_area = 2
+
+        area = polygon_area(x, y)
+
+        assert expected_area == area
+
+    def test_square(self):
+        x = np.array([-1, -1, 1, 1], dtype=np.float64)
+        y = np.array([-1, 1, 1, -1], dtype=np.float64)
+
+        expected_area = 4
+
+        area = polygon_area(x, y)
+
+        assert expected_area == area
+
+    def test_zero_area(self):
+        x = np.array([0, 0, 0], dtype=np.float64)
+        y = np.array([0, 0, 0], dtype=np.float64)
+
+        expected_area = 0
+
+        area = polygon_area(x, y)
+
+        assert expected_area == area


### PR DESCRIPTION
This pull request adds a method `pointtree.operations.polygon_area` that computes the area of a polygon from its vertices.