### PR TITLE
feat: estimate with linear model

### DIFF
--- a/mypy_stubs/sklearn/linear_model.pyi
+++ b/mypy_stubs/sklearn/linear_model.pyi
@@ -1,0 +1,18 @@
+__all__ = ["LinearRegression"]
+
+from typing import Optional, Union
+
+import numpy.typing as npt
+
+class LinearRegression:
+    def __init__(self, *, fit_intercept: bool = ..., copy_X: bool = ..., n_jobs: Optional[int] = ..., positive=bool):
+        self.coef_: npt.NDArray
+        self.rank_: int
+        self.singular_: npt.NDArray
+        self.intercept_: Union[float, npt.NDArray]
+        self.n_features_in_: int
+        self.feature_names_in_: npt.NDArray
+    def fit(
+        self, X: npt.ArrayLike, y: npt.ArrayLike, sample_weight: Optional[npt.ArrayLike] = None
+    ) -> LinearRegression: ...
+    def predict(self, X: npt.ArrayLike) -> npt.NDArray: ...

--- a/mypy_stubs/sklearn/linear_model.pyi
+++ b/mypy_stubs/sklearn/linear_model.pyi
@@ -5,7 +5,9 @@ from typing import Optional, Union
 import numpy.typing as npt
 
 class LinearRegression:
-    def __init__(self, *, fit_intercept: bool = ..., copy_X: bool = ..., n_jobs: Optional[int] = ..., positive=bool):
+    def __init__(
+        self, *, fit_intercept: bool = ..., copy_X: bool = ..., n_jobs: Optional[int] = ..., positive: bool = ...
+    ):
         self.coef_: npt.NDArray
         self.rank_: int
         self.singular_: npt.NDArray

--- a/src/pointtree/operations/__init__.py
+++ b/src/pointtree/operations/__init__.py
@@ -2,6 +2,7 @@
 
 from ._cloth_simulation_filtering import *
 from ._create_digital_terrain_model import *
+from ._estimate_with_linear_model import *
 from ._normalize_height import *
 from ._points_in_ellipse import *
 from ._polygon_area import *

--- a/src/pointtree/operations/_estimate_with_linear_model.py
+++ b/src/pointtree/operations/_estimate_with_linear_model.py
@@ -1,0 +1,48 @@
+""" Trains a linear model and computes the predictions of the model for the given data. """
+
+__all__ = ["estimate_with_linear_model"]
+
+from typing import Tuple
+
+import numpy as np
+import numpy.typing as npt
+from sklearn.linear_model import LinearRegression
+
+
+def estimate_with_linear_model(
+    x_train: npt.NDArray[np.float64], y_train: npt.NDArray[np.float64], x_predict: npt.NDArray[np.float64]
+) -> Tuple[npt.NDArray[np.float64], LinearRegression]:
+    r"""
+    Fits a linear model to the training data :code:`x_train` and :code:`y_train`, and computes the predictions of
+    the model for :code:`x_predict`.
+
+    Args:
+        x_train: Training data.
+        y_train: Target values.
+        x_predict: Inference data.
+
+    Returns:
+        Tuple of two elements. The first is an array containing the predictions for :code:`x_predict` and the second
+        is the fitted linear model.
+
+    Shape:
+        - :code:`x_train`: :math:`(N)` or :math:`(N, D)`
+        - :code:`y_train`: :math:`(N)`
+        - :code:`x_predict`: :math:`(N')` or :math:`(N', D)`
+        - Output: :math:`(N')`
+
+        | where
+        |
+        | :math:`N = \text{ number of training samples}`
+        | :math:`N' = \text{ number of inference samples}`
+        | :math:`D = \text{ number of input features}`
+    """
+
+    if x_train.ndim == 1:
+        x_train = x_train.reshape((-1, 1))
+    if x_predict.ndim == 1:
+        x_predict = x_predict.reshape((-1, 1))
+
+    regression = LinearRegression().fit(x_train, y_train)
+
+    return regression.predict(x_predict), regression

--- a/test/operations/test_estimate_with_linear_model.py
+++ b/test/operations/test_estimate_with_linear_model.py
@@ -23,7 +23,7 @@ class TestEstimateWithLinearModel:  # pylint: disable=too-few-public-methods
 
         predictions, linear_model = estimate_with_linear_model(x_train, y_train, x_predict)
 
-        np.testing.assert_array_equal(expected_predictions, predictions)
+        np.testing.assert_almost_equal(expected_predictions, predictions)
         if not expand_input_shape:
             x_predict = x_predict.reshape(-1, 1)
-        np.testing.assert_array_equal(expected_predictions, linear_model.predict(x_predict))
+        np.testing.assert_almost_equal(expected_predictions, linear_model.predict(x_predict))

--- a/test/operations/test_estimate_with_linear_model.py
+++ b/test/operations/test_estimate_with_linear_model.py
@@ -1,0 +1,29 @@
+""" Tests for pointtree.operations.estimate_with_linear_model. """
+
+import numpy as np
+import pytest
+
+from pointtree.operations import estimate_with_linear_model
+
+
+class TestEstimateWithLinearModel:  # pylint: disable=too-few-public-methods
+    """Tests for pointtree.operations.estimate_with_linear_model."""
+
+    @pytest.mark.parametrize("expand_input_shape", [True, False])
+    def test_estimate_with_linear_model(self, expand_input_shape: bool):
+        x_train = np.array([0, 1, 3], dtype=np.float64)
+        y_train = np.array([1, 2, 4], dtype=np.float64)
+        x_predict = np.array([2, 4], dtype=np.float64)
+
+        if expand_input_shape:
+            x_train = x_train.reshape(-1, 1)
+            x_predict = x_predict.reshape(-1, 1)
+
+        expected_predictions = np.array([3, 5], dtype=np.float64)
+
+        predictions, linear_model = estimate_with_linear_model(x_train, y_train, x_predict)
+
+        np.testing.assert_array_equal(expected_predictions, predictions)
+        if not expand_input_shape:
+            x_predict = x_predict.reshape(-1, 1)
+        np.testing.assert_array_equal(expected_predictions, linear_model.predict(x_predict))


### PR DESCRIPTION
This pull request adds a method `pointtorch.operations.estimate_with_linear_model` that fits a linear model to a training dataset and computes the model's predictions for a given dataset.