### PR TITLE
fix: instance segmentation metrics when all predictions are false positives or false negatives

### DIFF
--- a/src/pointtree/evaluation/_instance_segmentation_metrics.py
+++ b/src/pointtree/evaluation/_instance_segmentation_metrics.py
@@ -121,10 +121,10 @@ def instance_detection_metrics(  # pylint: disable=too-many-locals
         "TP": tp,
         "FP": fp,
         "FN": fn,
-        "Precision": tp / (tp + fp),
-        "CommissionError": fp / (tp + fp),
-        "Recall": tp / (tp + fn),
-        "OmissionError": fn / (tp + fn),
+        "Precision": tp / (tp + fp) if (tp + fp) > 0 else np.nan,
+        "CommissionError": fp / (tp + fp) if (tp + fp) > 0 else np.nan,
+        "Recall": tp / (tp + fn) if (tp + fn) > 0 else np.nan,
+        "OmissionError": fn / (tp + fn) if (tp + fn) > 0 else np.nan,
         "F1Score": 2 * tp / (2 * tp + fp + fn),
     }
 
@@ -180,12 +180,9 @@ def _compute_instance_segmentation_metrics(
         intersection = np.logical_and(target == target_id, prediction == predicted_id).sum()
         union = np.logical_or(target == target_id, prediction == predicted_id).sum()
 
-        if union > 0:
-            iou[target_id] = intersection / union
-        if (prediction == predicted_id).sum() > 0:
-            precision[target_id] = intersection / (prediction == predicted_id).sum()
-        if (target == target_id).sum() > 0:
-            recall[target_id] = intersection / (target == target_id).sum()
+        iou[target_id] = intersection / union
+        precision[target_id] = intersection / (prediction == predicted_id).sum()
+        recall[target_id] = intersection / (target == target_id).sum()
 
     return iou, precision, recall
 

--- a/src/pointtree/evaluation/_match_instances.py
+++ b/src/pointtree/evaluation/_match_instances.py
@@ -117,6 +117,11 @@ def match_instances(
     unique_prediction_ids = np.unique(prediction)
     unique_prediction_ids = unique_prediction_ids[unique_prediction_ids != invalid_instance_id]
 
+    if len(unique_target_ids) == 0 or len(unique_prediction_ids) == 0:
+        matched_target_ids = np.full(len(unique_prediction_ids), fill_value=invalid_instance_id, dtype=np.int64)
+        matched_predicted_ids = np.full(len(unique_target_ids), fill_value=invalid_instance_id, dtype=np.int64)
+        return matched_target_ids, matched_predicted_ids
+
     if unique_target_ids.min() != 0 or unique_target_ids.max() != len(unique_target_ids) - 1:
         raise ValueError("The target instance IDs must be continuous, starting with zero.")
 

--- a/test/evaluation/test_instance_segmentation_metrics.py
+++ b/test/evaluation/test_instance_segmentation_metrics.py
@@ -114,6 +114,50 @@ class TestInstanceSegmentationMetrics:
                 invalid_instance_id=-1,
             )
 
+    def test_instance_detection_metrics_all_false_negatives(self):
+        target = np.array([1, 1, 1, 0, 0], dtype=np.int64)
+        prediction = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
+
+        matched_predicted_ids = np.array([-1, -1], dtype=np.int64)
+        matched_target_ids = np.array([], dtype=np.int64)
+
+        metrics = instance_detection_metrics(
+            target,
+            prediction,
+            matched_predicted_ids,
+            matched_target_ids,
+            invalid_instance_id=-1,
+        )
+
+        assert metrics["TP"] == 0
+        assert metrics["FP"] == 0
+        assert metrics["FN"] == 2
+        assert np.isnan(metrics["Precision"])
+        assert np.isnan(metrics["CommissionError"])
+        assert metrics["Recall"] == 0
+        assert metrics["OmissionError"] == 1
+        assert metrics["F1Score"] == 0
+
+    def test_instance_detection_metrics_all_false_positives(self):
+        target = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
+        prediction = np.array([1, 1, 1, 0, 0], dtype=np.int64)
+
+        matched_predicted_ids = np.array([], dtype=np.int64)
+        matched_target_ids = np.array([-1, -1], dtype=np.int64)
+
+        metrics = instance_detection_metrics(
+            target, prediction, matched_predicted_ids, matched_target_ids, invalid_instance_id=-1, min_precision_fp=0
+        )
+
+        assert metrics["TP"] == 0
+        assert metrics["FP"] == 2
+        assert metrics["FN"] == 0
+        assert metrics["Precision"] == 0
+        assert metrics["CommissionError"] == 1
+        assert np.isnan(metrics["Recall"])
+        assert np.isnan(metrics["OmissionError"])
+        assert metrics["F1Score"] == 0
+
     def test_instance_segmentation_metrics(self):
         target = np.array([1, 1, 1, 1, 0, 0, 0, 0, -1, 2], dtype=np.int64)
         prediction = np.array([0, 1, 0, 0, 0, 2, 2, 2, -1, -1], dtype=np.int64)

--- a/test/evaluation/test_instance_segmentation_metrics.py
+++ b/test/evaluation/test_instance_segmentation_metrics.py
@@ -11,7 +11,7 @@ from pointtree.evaluation import (
 )
 
 
-class TestInstanceSegmentationMetrics:
+class TestInstanceSegmentationMetrics:  # pylint: disable=too-many-public-methods
     """Tests for pointtree.evaluation.instance_segmentation_metrics."""
 
     @pytest.mark.parametrize("min_precision_fp", [0.5, 0.6])

--- a/test/evaluation/test_match_instances.py
+++ b/test/evaluation/test_match_instances.py
@@ -81,6 +81,50 @@ class TestMetrics:
             "tree_learn",
         ],
     )
+    def test_match_instances_all_false_negatives(self, method: str):
+        xyz = np.random.randn(6, 3)
+        target = np.array([0, 0, 1, 1, 2, 2], dtype=np.int64)
+        prediction = np.full(len(target), fill_value=-1, dtype=np.int64)
+
+        matched_target_ids, matched_predicted_ids = match_instances(xyz, target, prediction, method=method)
+
+        np.testing.assert_array_equal(np.array([], dtype=np.int64), matched_target_ids)
+        np.testing.assert_array_equal(np.array([-1, -1, -1], dtype=np.int64), matched_predicted_ids)
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "panoptic_segmentation",
+            "point2tree",
+            "for_instance",
+            "for_ai_net",
+            "for_ai_net_coverage",
+            "segment_any_tree",
+            "tree_learn",
+        ],
+    )
+    def test_match_instances_all_false_positives(self, method: str):
+        xyz = np.random.randn(6, 3)
+        prediction = np.array([0, 0, 1, 1, 2, 2], dtype=np.int64)
+        target = np.full(len(prediction), fill_value=-1, dtype=np.int64)
+
+        matched_target_ids, matched_predicted_ids = match_instances(xyz, target, prediction, method=method)
+
+        np.testing.assert_array_equal(np.array([-1, -1, -1], dtype=np.int64), matched_target_ids)
+        np.testing.assert_array_equal(np.array([], dtype=np.int64), matched_predicted_ids)
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "panoptic_segmentation",
+            "point2tree",
+            "for_instance",
+            "for_ai_net",
+            "for_ai_net_coverage",
+            "segment_any_tree",
+            "tree_learn",
+        ],
+    )
     def test_match_instances_non_continuous_target_ids(self, method: str):
         target = np.array([0, 2], dtype=np.int64)
         prediction = np.zeros_like(target)


### PR DESCRIPTION
The pull request fixes the instance segmentation metrics to correctly handle cases where all predictions are false positives or false negatives.